### PR TITLE
Add KickBot web panel and bot runner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+instance/
+*.pyc
+*.db
+logs/

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Environment variables:
 
 ## Bots
 
-Each bot requires a Kick `auth_token` which can be obtained using `scripts/login_kick.py`. Bots belong to optional *groups* so you can trigger messages for multiple bots at once. Logs can be viewed per bot from the dashboard and you can start all bots or a single group via dashboard buttons.
+Each bot requires a Kick `auth_token`. You can obtain a token with the helper script `scripts/login_kick.py` or by calling the `/login_kick` API endpoint with your Kick credentials. Bots belong to optional *groups* so you can trigger messages for multiple bots at once. Logs can be viewed per bot from the dashboard and you can start all bots or a single group via dashboard buttons.
 
 When creating or editing a bot in the dashboard, leave the group field blank if you do not want the bot included in group actions.
 
@@ -50,7 +50,7 @@ When creating or editing a bot in the dashboard, leave the group field blank if 
 
 - `scripts/add_bot.py` – create a bot via the API
 - `scripts/run_bot.py` – run a standalone bot
-- `scripts/login_kick.py` – retrieve a Kick auth token
+- `scripts/login_kick.py` – retrieve a Kick auth token (same as `/login_kick` API)
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ pip install -r requirements.txt
 # optional environment variables can be set before running
 # for example, launch the app on port 8000 without debug:
 PORT=8000 DEBUG=false python run.py
+# you can also run `python backend/app.py` directly, but `run.py` ensures the
+# dashboard blueprint is registered
 ```
 
 If the selected port is already taken, the server automatically falls back to a

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ KickBot is a simple web panel for managing chat bots for [Kick.com](https://kick
 - Create, edit and delete bots with individual messages and intervals
 - Manual "Send now" button and automatic scheduling
 - Logs stored in a local SQLite database
+- Optional bot groups with "Start All" and "Start group" actions
 - Web dashboard with live bot and log updates
 
 ## Setup
@@ -41,7 +42,9 @@ Environment variables:
 
 ## Bots
 
-Each bot requires a Kick `auth_token` which can be obtained using `scripts/login_kick.py`. Bots are created and scheduled automatically. Logs can be viewed per bot from the dashboard.
+Each bot requires a Kick `auth_token` which can be obtained using `scripts/login_kick.py`. Bots belong to optional *groups* so you can trigger messages for multiple bots at once. Logs can be viewed per bot from the dashboard and you can start all bots or a single group via dashboard buttons.
+
+When creating or editing a bot in the dashboard, leave the group field blank if you do not want the bot included in group actions.
 
 ## Scripts
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,59 @@
-# kick-multibot-panel
+# KickBot Dashboard
+
+KickBot is a simple web panel for managing chat bots for [Kick.com](https://kick.com). Bots send messages to channels over WebSocket on a schedule and can be controlled from the dashboard.
+
+## Features
+
+- Login page (`admin`/`admin`)
+- Create, edit and delete bots with individual messages and intervals
+- Manual "Send now" button and automatic scheduling
+- Logs stored in a local SQLite database
+- Web dashboard with live bot and log updates
+
+## Setup
+
+Install dependencies and start the server:
+
+```bash
+pip install -r requirements.txt
+# optional environment variables can be set before running
+# for example, launch the app on port 8000 without debug:
+PORT=8000 DEBUG=false python run.py
+```
+
+If the selected port is already taken, the server automatically falls back to a
+random free port and prints a notice.
+
+Open `http://localhost:<PORT>/login` (replace `<PORT>` with your chosen port) and sign in. After logging in, the dashboard
+lets you manage up to 1000 bots.
+
+Environment variables:
+
+- `DB_PATH` – path to the SQLite file (default `bots.db`)
+- `KICK_URI` – Kick WebSocket URI
+- `WORKERS` – scheduler thread pool size
+- `MAX_INSTANCES` – max concurrent jobs
+- `SECRET_KEY` – session secret
+- `PORT` – server port (default `5000`)
+- `DEBUG` – set to `false` to disable Flask debug mode
+
+## Bots
+
+Each bot requires a Kick `auth_token` which can be obtained using `scripts/login_kick.py`. Bots are created and scheduled automatically. Logs can be viewed per bot from the dashboard.
+
+## Scripts
+
+- `scripts/add_bot.py` – create a bot via the API
+- `scripts/run_bot.py` – run a standalone bot
+- `scripts/login_kick.py` – retrieve a Kick auth token
+
+## Testing
+
+Run a quick smoke test to ensure the code compiles and the server starts:
+
+```bash
+python -m py_compile backend/app.py app/routes.py run.py \
+    bots/bot_runner.py scripts/add_bot.py scripts/login_kick.py \
+    scripts/run_bot.py shared/logger.py
+python run.py & sleep 3; pkill -f run.py
+```

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ Environment variables:
 - `SECRET_KEY` – session secret
 - `PORT` – server port (default `5000`)
 - `DEBUG` – set to `false` to disable Flask debug mode
+- Scheduler jobs run with the Flask application context so logs are reliably
+  recorded to the database
 
 ## Bots
 

--- a/app/routes.py
+++ b/app/routes.py
@@ -1,0 +1,44 @@
+from functools import wraps
+from flask import Blueprint, render_template, request, redirect, url_for, session, flash
+
+bp = Blueprint('panel', __name__)
+
+def login_required(func):
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        if 'user' not in session:
+            return redirect(url_for('panel.login'))
+        return func(*args, **kwargs)
+    return wrapper
+
+@bp.route('/')
+def index():
+    if 'user' in session:
+        return redirect(url_for('panel.dashboard'))
+    return redirect(url_for('panel.login'))
+
+@bp.route('/login', methods=['GET', 'POST'])
+def login():
+    if request.method == 'POST':
+        if request.form.get('username') == 'admin' and request.form.get('password') == 'admin':
+            session['user'] = 'admin'
+            return redirect(url_for('panel.dashboard'))
+        flash('Invalid credentials')
+    return render_template('login.html')
+
+@bp.route('/logout')
+def logout():
+    session.pop('user', None)
+    return redirect(url_for('panel.login'))
+
+@bp.route('/dashboard')
+@login_required
+def dashboard():
+    return render_template('dashboard.html')
+
+
+def register_web(app):
+    """Register blueprint with the given Flask app."""
+    app.register_blueprint(bp)
+    # provide an alias so url_for('dashboard') works
+    app.add_url_rule('/dashboard', 'dashboard', dashboard)

--- a/app/static/main.js
+++ b/app/static/main.js
@@ -13,13 +13,15 @@ async function fetchBots() {
       `<td>${bot.channel}</td>` +
       `<td>${bot.message}</td>` +
       `<td>${bot.interval}</td>` +
+      `<td>${bot.group || ''}</td>` +
       `<td>${bot.active ? '✅' : '❌'}</td>` +
       `<td>` +
       `<button onclick="sendNow(${bot.id})">Send</button> ` +
       `<button onclick="toggleBot(${bot.id})">Toggle</button> ` +
       `<button onclick="openEdit(${bot.id})">Edit</button> ` +
       `<button onclick="deleteBot(${bot.id})">Delete</button> ` +
-      `<button onclick="viewLogs(${bot.id})">Logs</button>` +
+      `<button onclick="viewLogs(${bot.id})">Logs</button> ` +
+      `<button onclick="startGroup('${bot.group}')">Start group</button>` +
       `</td>`;
     tbody.appendChild(row);
   });
@@ -56,6 +58,17 @@ async function sendNow(id) {
   fetchLogs();
 }
 
+async function startGroup(name) {
+  if (!name) return;
+  await fetch(`/start_group/${encodeURIComponent(name)}`, {method: 'POST'}).catch(() => null);
+  fetchLogs();
+}
+
+async function startAll() {
+  await fetch('/start_all', {method: 'POST'}).catch(() => null);
+  fetchLogs();
+}
+
 async function toggleBot(id) {
   await fetch(`/bots/${id}/toggle`, {method: 'POST'}).catch(() => null);
   fetchBots();
@@ -75,6 +88,7 @@ function openEdit(id) {
       document.getElementById('edit-message').value = bot.message;
       document.getElementById('edit-interval').value = bot.interval;
       document.getElementById('edit-token').value = bot.token;
+      document.getElementById('edit-group').value = bot.group || '';
       document.getElementById('edit-active').checked = bot.active;
       document.getElementById('editDialog').showModal();
     })
@@ -92,6 +106,7 @@ document.getElementById('botForm').addEventListener('submit', async e => {
     message: document.getElementById('message').value,
     interval: parseInt(document.getElementById('interval').value, 10),
     token: document.getElementById('token').value,
+    group: document.getElementById('group').value,
     active: document.getElementById('active').checked
   };
   await fetch('/bots', {method: 'POST', headers: {'Content-Type': 'application/json'}, body: JSON.stringify(data)}).catch(() => null);
@@ -107,6 +122,7 @@ document.getElementById('editForm').addEventListener('submit', async e => {
     message: document.getElementById('edit-message').value,
     interval: parseInt(document.getElementById('edit-interval').value, 10),
     token: document.getElementById('edit-token').value,
+    group: document.getElementById('edit-group').value,
     active: document.getElementById('edit-active').checked
   };
   await fetch(`/bots/${id}`, {method: 'PUT', headers: {'Content-Type': 'application/json'}, body: JSON.stringify(data)}).catch(() => null);

--- a/app/static/main.js
+++ b/app/static/main.js
@@ -1,0 +1,120 @@
+let botCache = [];
+
+async function fetchBots() {
+  const res = await fetch('/bots').catch(() => null);
+  if (!res) return;
+  botCache = await res.json();
+  const tbody = document.querySelector('#botTable tbody');
+  tbody.innerHTML = '';
+  botCache.forEach(bot => {
+    const row = document.createElement('tr');
+    row.innerHTML =
+      `<td>${bot.id}</td>` +
+      `<td>${bot.channel}</td>` +
+      `<td>${bot.message}</td>` +
+      `<td>${bot.interval}</td>` +
+      `<td>${bot.active ? '✅' : '❌'}</td>` +
+      `<td>` +
+      `<button onclick="sendNow(${bot.id})">Send</button> ` +
+      `<button onclick="toggleBot(${bot.id})">Toggle</button> ` +
+      `<button onclick="openEdit(${bot.id})">Edit</button> ` +
+      `<button onclick="deleteBot(${bot.id})">Delete</button> ` +
+      `<button onclick="viewLogs(${bot.id})">Logs</button>` +
+      `</td>`;
+    tbody.appendChild(row);
+  });
+}
+
+async function fetchLogs() {
+  const res = await fetch('/logs').catch(() => null);
+  if (!res) return;
+  const logs = await res.json();
+  const tbody = document.querySelector('#logTable tbody');
+  tbody.innerHTML = '';
+  logs.forEach(log => {
+    const row = document.createElement('tr');
+    row.innerHTML = `<td>${log.timestamp}</td><td>${log.channel}</td><td>${log.message}</td>`;
+    tbody.appendChild(row);
+  });
+}
+
+async function viewLogs(id) {
+  const res = await fetch(`/bots/${id}/logs`).catch(() => null);
+  if (!res) return;
+  const logs = await res.json();
+  const tbody = document.querySelector('#logTable tbody');
+  tbody.innerHTML = '';
+  logs.forEach(log => {
+    const row = document.createElement('tr');
+    row.innerHTML = `<td>${log.timestamp}</td><td>${log.channel}</td><td>${log.message}</td>`;
+    tbody.appendChild(row);
+  });
+}
+
+async function sendNow(id) {
+  await fetch(`/bots/${id}/send`, {method: 'POST'}).catch(() => null);
+  fetchLogs();
+}
+
+async function toggleBot(id) {
+  await fetch(`/bots/${id}/toggle`, {method: 'POST'}).catch(() => null);
+  fetchBots();
+}
+
+async function deleteBot(id) {
+  await fetch(`/bots/${id}`, {method: 'DELETE'}).catch(() => null);
+  fetchBots();
+}
+
+function openEdit(id) {
+  fetch(`/bots/${id}`)
+    .then(res => res.json())
+    .then(bot => {
+      document.getElementById('edit-id').value = bot.id;
+      document.getElementById('edit-channel').value = bot.channel;
+      document.getElementById('edit-message').value = bot.message;
+      document.getElementById('edit-interval').value = bot.interval;
+      document.getElementById('edit-token').value = bot.token;
+      document.getElementById('edit-active').checked = bot.active;
+      document.getElementById('editDialog').showModal();
+    })
+    .catch(() => null);
+}
+
+function closeEdit() {
+  document.getElementById('editDialog').close();
+}
+
+document.getElementById('botForm').addEventListener('submit', async e => {
+  e.preventDefault();
+  const data = {
+    channel: document.getElementById('channel').value,
+    message: document.getElementById('message').value,
+    interval: parseInt(document.getElementById('interval').value, 10),
+    token: document.getElementById('token').value,
+    active: document.getElementById('active').checked
+  };
+  await fetch('/bots', {method: 'POST', headers: {'Content-Type': 'application/json'}, body: JSON.stringify(data)}).catch(() => null);
+  e.target.reset();
+  fetchBots();
+});
+
+document.getElementById('editForm').addEventListener('submit', async e => {
+  e.preventDefault();
+  const id = document.getElementById('edit-id').value;
+  const data = {
+    channel: document.getElementById('edit-channel').value,
+    message: document.getElementById('edit-message').value,
+    interval: parseInt(document.getElementById('edit-interval').value, 10),
+    token: document.getElementById('edit-token').value,
+    active: document.getElementById('edit-active').checked
+  };
+  await fetch(`/bots/${id}`, {method: 'PUT', headers: {'Content-Type': 'application/json'}, body: JSON.stringify(data)}).catch(() => null);
+  closeEdit();
+  fetchBots();
+});
+
+fetchBots();
+fetchLogs();
+setInterval(fetchLogs, 5000);
+setInterval(fetchBots, 5000);

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -1,0 +1,8 @@
+table th, table td {
+  border: 1px solid #ddd;
+  padding: 4px 8px;
+}
+
+table th {
+  background-color: #f3f4f6;
+}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>{% block title %}KickBot{% endblock %}</title>
+  <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
+</head>
+<body class="p-4">
+  {% with messages = get_flashed_messages() %}
+    {% if messages %}
+      <ul class="mb-4">
+        {% for m in messages %}
+          <li class="bg-green-200 p-2 mb-2">{{ m }}</li>
+        {% endfor %}
+      </ul>
+    {% endif %}
+  {% endwith %}
+  {% if session.get('user') %}
+    <a href="{{ url_for('panel.logout') }}" class="text-blue-600 underline">Logout</a>
+  {% endif %}
+  {% block content %}{% endblock %}
+</body>
+</html>

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -9,15 +9,17 @@
     Message: <input type="text" id="message" class="border" required> <br>
     Interval (sec): <input type="number" id="interval" value="600" class="border" required> <br>
     Token: <input type="text" id="token" class="border" required> <br>
+    Group: <input type="text" id="group" class="border"> <br>
     Active: <input type="checkbox" id="active" checked> <br>
     <button type="submit" class="bg-green-500 text-white px-2 py-1">Create</button>
   </form>
 </div>
 
 <h2 class="text-lg font-bold mt-6">Bots</h2>
+<button onclick="startAll()" class="bg-purple-500 text-white px-2 py-1 mb-2">Start All</button>
 <table id="botTable" class="w-full border-collapse mb-4">
   <thead>
-    <tr><th>ID</th><th>Channel</th><th>Message</th><th>Interval</th><th>Active</th><th>Actions</th></tr>
+    <tr><th>ID</th><th>Channel</th><th>Message</th><th>Interval</th><th>Group</th><th>Active</th><th>Actions</th></tr>
   </thead>
   <tbody></tbody>
 </table>
@@ -29,6 +31,7 @@
     Message: <input type="text" id="edit-message" required><br>
     Interval (sec): <input type="number" id="edit-interval" required><br>
     Token: <input type="text" id="edit-token" required><br>
+    Group: <input type="text" id="edit-group"><br>
     Active: <input type="checkbox" id="edit-active"><br>
     <button type="submit" class="bg-blue-500 text-white px-2 py-1">Save</button>
     <button type="button" onclick="closeEdit()">Cancel</button>

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -1,0 +1,48 @@
+{% extends 'base.html' %}
+{% block title %}Dashboard{% endblock %}
+{% block content %}
+<h1 class="text-xl mb-4">Kick Multibot Panel</h1>
+<div>
+  <h2 class="text-lg font-bold mb-2">Add Bot</h2>
+  <form id="botForm" class="space-y-2">
+    Channel: <input type="text" id="channel" class="border" required> <br>
+    Message: <input type="text" id="message" class="border" required> <br>
+    Interval (sec): <input type="number" id="interval" value="600" class="border" required> <br>
+    Token: <input type="text" id="token" class="border" required> <br>
+    Active: <input type="checkbox" id="active" checked> <br>
+    <button type="submit" class="bg-green-500 text-white px-2 py-1">Create</button>
+  </form>
+</div>
+
+<h2 class="text-lg font-bold mt-6">Bots</h2>
+<table id="botTable" class="w-full border-collapse mb-4">
+  <thead>
+    <tr><th>ID</th><th>Channel</th><th>Message</th><th>Interval</th><th>Active</th><th>Actions</th></tr>
+  </thead>
+  <tbody></tbody>
+</table>
+
+<dialog id="editDialog">
+  <form id="editForm" class="space-y-2">
+    <input type="hidden" id="edit-id">
+    Channel: <input type="text" id="edit-channel" required><br>
+    Message: <input type="text" id="edit-message" required><br>
+    Interval (sec): <input type="number" id="edit-interval" required><br>
+    Token: <input type="text" id="edit-token" required><br>
+    Active: <input type="checkbox" id="edit-active"><br>
+    <button type="submit" class="bg-blue-500 text-white px-2 py-1">Save</button>
+    <button type="button" onclick="closeEdit()">Cancel</button>
+  </form>
+</dialog>
+
+<h2 class="text-lg font-bold mt-6">Logs</h2>
+<table id="logTable" class="w-full border-collapse">
+  <thead>
+    <tr><th>Time</th><th>Channel</th><th>Message</th></tr>
+  </thead>
+  <tbody></tbody>
+</table>
+<p class="mt-2">Use the <strong>Logs</strong> button next to a bot to filter logs.</p>
+
+<script src="{{ url_for('static', filename='main.js') }}"></script>
+{% endblock %}

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -1,0 +1,10 @@
+{% extends 'base.html' %}
+{% block title %}Login{% endblock %}
+{% block content %}
+<h1 class="text-xl mb-4">Login</h1>
+<form method="post" class="space-y-2">
+  <input type="text" name="username" placeholder="Username" class="border p-2 w-full" required>
+  <input type="password" name="password" placeholder="Password" class="border p-2 w-full" required>
+  <button type="submit" class="bg-blue-500 text-white px-4 py-2">Login</button>
+</form>
+{% endblock %}

--- a/backend/app.py
+++ b/backend/app.py
@@ -9,6 +9,7 @@ from threading import Thread
 
 from flask import Flask, request, jsonify
 from flask_sqlalchemy import SQLAlchemy
+from sqlalchemy import inspect, text
 from apscheduler.schedulers.background import BackgroundScheduler
 from apscheduler.executors.pool import ThreadPoolExecutor
 import websockets
@@ -37,6 +38,7 @@ class Bot(db.Model):
     interval = db.Column(db.Integer, nullable=False)
     token = db.Column(db.String(200), nullable=False)
     active = db.Column(db.Boolean, default=True)
+    group = db.Column(db.String(80))
 
 class Log(db.Model):
     id = db.Column(db.Integer, primary_key=True)
@@ -140,6 +142,7 @@ def list_bots():
             "interval": b.interval,
             "token": b.token,
             "active": b.active,
+            "group": b.group,
         }
         for b in bots
     ])
@@ -153,6 +156,7 @@ def create_bot():
         interval=data["interval"],
         token=data["token"],
         active=data.get("active", True),
+        group=data.get("group"),
     )
     db.session.add(bot)
     db.session.commit()
@@ -170,6 +174,7 @@ def get_bot(bot_id):
         'interval': bot.interval,
         'token': bot.token,
         'active': bot.active,
+        'group': bot.group,
     })
 
 @app.route('/bots/<int:bot_id>', methods=['PUT'])
@@ -181,6 +186,7 @@ def update_bot(bot_id):
     bot.interval = data.get('interval', bot.interval)
     bot.token = data.get('token', bot.token)
     bot.active = data.get('active', bot.active)
+    bot.group = data.get('group', bot.group)
     db.session.commit()
     schedule_bot(bot)
     return jsonify({'status': 'updated'})
@@ -209,6 +215,26 @@ def send_now(bot_id):
         schedule_job(bot.id, bot.token, bot.channel, bot.message), aio_loop
     )
     return jsonify({'status': 'sent'})
+
+@app.route('/start_all', methods=['POST'])
+def start_all():
+    """Trigger all active bots once."""
+    bots = Bot.query.filter_by(active=True).all()
+    for bot in bots:
+        asyncio.run_coroutine_threadsafe(
+            schedule_job(bot.id, bot.token, bot.channel, bot.message), aio_loop
+        )
+    return jsonify({'count': len(bots)})
+
+@app.route('/start_group/<group>', methods=['POST'])
+def start_group(group):
+    """Trigger all active bots in a group."""
+    bots = Bot.query.filter_by(group=group, active=True).all()
+    for bot in bots:
+        asyncio.run_coroutine_threadsafe(
+            schedule_job(bot.id, bot.token, bot.channel, bot.message), aio_loop
+        )
+    return jsonify({'count': len(bots)})
 
 @app.route('/logs', methods=['GET'])
 def get_logs():
@@ -239,6 +265,12 @@ def create_app():
     """Return the configured Flask app."""
     with app.app_context():
         db.create_all()
+        # add missing columns for upgrades
+        insp = inspect(db.engine)
+        cols = [c['name'] for c in insp.get_columns('bot')]
+        if 'group' not in cols:
+            with db.engine.begin() as conn:
+                conn.execute(text('ALTER TABLE bot ADD COLUMN "group" VARCHAR(80)'))
         initialize_jobs()
         register_web(app)
     return app

--- a/backend/app.py
+++ b/backend/app.py
@@ -16,6 +16,7 @@ import websockets
 
 from app.routes import register_web
 from shared.kick import login as kick_login
+from shared.logger import logger
 
 # retry attempts for websocket messages
 MAX_RETRIES = 3
@@ -77,7 +78,7 @@ class KickClient:
                 )
                 return
             except Exception as exc:  # pragma: no cover - connection errors
-                print(f"connect attempt {attempt} failed: {exc}")
+                logger.warning("connect attempt %s failed: %s", attempt, exc)
                 await asyncio.sleep(1)
         raise ConnectionError("Unable to connect to Kick chat")
 
@@ -91,7 +92,7 @@ class KickClient:
                     await self.ws.send(payload)
                     return
                 except Exception as exc:
-                    print(f"send failed attempt {attempt}: {exc}")
+                    logger.warning("send failed attempt %s: %s", attempt, exc)
                     await self._connect()
             raise ConnectionError("Send retries exceeded")
 
@@ -112,9 +113,10 @@ async def send_kick_message(token: str, channel: str, message: str):
 
 async def schedule_job(bot_id: int, token: str, channel: str, message: str):
     await send_kick_message(token, channel, message)
-    log = Log(bot_id=bot_id, message=message, channel=channel)
-    db.session.add(log)
-    db.session.commit()
+    with app.app_context():
+        log = Log(bot_id=bot_id, message=message, channel=channel)
+        db.session.add(log)
+        db.session.commit()
 
 def start_async_loop(loop):
     asyncio.set_event_loop(loop)

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,0 +1,245 @@
+"""Backend service for managing Kick chat bots."""
+
+import asyncio
+import json
+from datetime import datetime
+from pathlib import Path
+import os
+from threading import Thread
+
+from flask import Flask, request, jsonify
+from flask_sqlalchemy import SQLAlchemy
+from apscheduler.schedulers.background import BackgroundScheduler
+from apscheduler.executors.pool import ThreadPoolExecutor
+import websockets
+
+# retry attempts for websocket messages
+MAX_RETRIES = 3
+
+BASE_DIR = Path(__file__).resolve().parent
+app = Flask(
+    __name__,
+    static_folder=str(BASE_DIR.parent / "app" / "static"),
+    template_folder=str(BASE_DIR.parent / "app" / "templates"),
+)
+app.config["SECRET_KEY"] = os.getenv("SECRET_KEY", "change-me")
+db_path = os.getenv("DB_PATH", "bots.db")
+app.config["SQLALCHEMY_DATABASE_URI"] = f"sqlite:///{db_path}"
+app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
+db = SQLAlchemy(app)
+
+class Bot(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    channel = db.Column(db.String(80), nullable=False)
+    message = db.Column(db.String(200), nullable=False)
+    interval = db.Column(db.Integer, nullable=False)
+    token = db.Column(db.String(200), nullable=False)
+    active = db.Column(db.Boolean, default=True)
+
+class Log(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    bot_id = db.Column(db.Integer, db.ForeignKey('bot.id'))
+    timestamp = db.Column(db.DateTime, default=datetime.utcnow)
+    message = db.Column(db.String(200))
+    channel = db.Column(db.String(80))
+
+sched_workers = int(os.getenv("WORKERS", "100"))
+max_instances = int(os.getenv("MAX_INSTANCES", "50"))
+scheduler = BackgroundScheduler(
+    executors={"default": ThreadPoolExecutor(max_workers=sched_workers)},
+    job_defaults={"max_instances": max_instances},
+)
+scheduler.start()
+
+class KickClient:
+    """Minimal WebSocket client with reconnect logic for a user."""
+
+    def __init__(self, uri: str, token: str):
+        self.uri = uri
+        self.token = token
+        self.ws = None
+        self._lock = asyncio.Lock()
+
+    async def _connect(self):
+        for attempt in range(1, MAX_RETRIES + 1):
+            try:
+                headers = {"Authorization": f"Bearer {self.token}"}
+                self.ws = await websockets.connect(
+                    self.uri,
+                    extra_headers=headers,
+                    ping_interval=20,
+                    ping_timeout=20,
+                )
+                return
+            except Exception as exc:  # pragma: no cover - connection errors
+                print(f"connect attempt {attempt} failed: {exc}")
+                await asyncio.sleep(1)
+        raise ConnectionError("Unable to connect to Kick chat")
+
+    async def send(self, channel: str, message: str):
+        payload = json.dumps({"channel": channel, "message": message})
+        async with self._lock:
+            if not self.ws or self.ws.closed:
+                await self._connect()
+            for attempt in range(1, MAX_RETRIES + 1):
+                try:
+                    await self.ws.send(payload)
+                    return
+                except Exception as exc:
+                    print(f"send failed attempt {attempt}: {exc}")
+                    await self._connect()
+            raise ConnectionError("Send retries exceeded")
+
+
+KICK_URI = os.getenv("KICK_URI", "wss://chat.kick.com")
+_clients = {}
+
+def get_client(token: str) -> "KickClient":
+    """Return a cached KickClient for a given token."""
+    if token not in _clients:
+        _clients[token] = KickClient(KICK_URI, token)
+    return _clients[token]
+
+async def send_kick_message(token: str, channel: str, message: str):
+    """Send a message using a user's token."""
+    client = get_client(token)
+    await client.send(channel, message)
+
+async def schedule_job(bot_id: int, token: str, channel: str, message: str):
+    await send_kick_message(token, channel, message)
+    log = Log(bot_id=bot_id, message=message, channel=channel)
+    db.session.add(log)
+    db.session.commit()
+
+def start_async_loop(loop):
+    asyncio.set_event_loop(loop)
+    loop.run_forever()
+
+# Background asyncio event loop
+aio_loop = asyncio.new_event_loop()
+thread = Thread(target=start_async_loop, args=(aio_loop,))
+thread.daemon = True
+thread.start()
+
+# Initialize database
+def initialize_jobs():
+    """Schedule all bots from the database on startup."""
+    for bot in Bot.query.all():
+        schedule_bot(bot)
+
+@app.route('/bots', methods=['GET'])
+def list_bots():
+    bots = Bot.query.all()
+    return jsonify([
+        {
+            "id": b.id,
+            "channel": b.channel,
+            "message": b.message,
+            "interval": b.interval,
+            "token": b.token,
+            "active": b.active,
+        }
+        for b in bots
+    ])
+
+@app.route('/bots', methods=['POST'])
+def create_bot():
+    data = request.json
+    bot = Bot(
+        channel=data["channel"],
+        message=data["message"],
+        interval=data["interval"],
+        token=data["token"],
+        active=data.get("active", True),
+    )
+    db.session.add(bot)
+    db.session.commit()
+    schedule_bot(bot)
+    return jsonify({'id': bot.id}), 201
+
+@app.route('/bots/<int:bot_id>', methods=['GET'])
+def get_bot(bot_id):
+    """Return single bot details."""
+    bot = Bot.query.get_or_404(bot_id)
+    return jsonify({
+        'id': bot.id,
+        'channel': bot.channel,
+        'message': bot.message,
+        'interval': bot.interval,
+        'token': bot.token,
+        'active': bot.active,
+    })
+
+@app.route('/bots/<int:bot_id>', methods=['PUT'])
+def update_bot(bot_id):
+    bot = Bot.query.get_or_404(bot_id)
+    data = request.json
+    bot.channel = data.get('channel', bot.channel)
+    bot.message = data.get('message', bot.message)
+    bot.interval = data.get('interval', bot.interval)
+    bot.token = data.get('token', bot.token)
+    bot.active = data.get('active', bot.active)
+    db.session.commit()
+    schedule_bot(bot)
+    return jsonify({'status': 'updated'})
+
+@app.route('/bots/<int:bot_id>', methods=['DELETE'])
+def delete_bot(bot_id):
+    bot = Bot.query.get_or_404(bot_id)
+    scheduler.remove_job(str(bot.id))
+    db.session.delete(bot)
+    db.session.commit()
+    return jsonify({'status': 'deleted'})
+
+@app.route('/bots/<int:bot_id>/toggle', methods=['POST'])
+def toggle_bot(bot_id):
+    """Toggle bot active state."""
+    bot = Bot.query.get_or_404(bot_id)
+    bot.active = not bot.active
+    db.session.commit()
+    schedule_bot(bot)
+    return jsonify({'active': bot.active})
+
+@app.route('/bots/<int:bot_id>/send', methods=['POST'])
+def send_now(bot_id):
+    bot = Bot.query.get_or_404(bot_id)
+    asyncio.run_coroutine_threadsafe(
+        schedule_job(bot.id, bot.token, bot.channel, bot.message), aio_loop
+    )
+    return jsonify({'status': 'sent'})
+
+@app.route('/logs', methods=['GET'])
+def get_logs():
+    logs = Log.query.order_by(Log.timestamp.desc()).limit(50).all()
+    return jsonify([{"id": l.id, "bot_id": l.bot_id, "timestamp": l.timestamp.isoformat(),
+                     "message": l.message, "channel": l.channel} for l in logs])
+
+@app.route('/bots/<int:bot_id>/logs', methods=['GET'])
+def get_bot_logs(bot_id):
+    """Return recent logs for a single bot."""
+    logs = Log.query.filter_by(bot_id=bot_id).order_by(Log.timestamp.desc()).limit(50).all()
+    return jsonify([{"id": l.id, "timestamp": l.timestamp.isoformat(), "message": l.message,
+                     "channel": l.channel} for l in logs])
+
+def schedule_bot(bot: Bot):
+    """Create or update a scheduled job for the bot."""
+    if scheduler.get_job(str(bot.id)):
+        scheduler.remove_job(str(bot.id))
+    if bot.active:
+        scheduler.add_job(
+            lambda: asyncio.run_coroutine_threadsafe(
+                schedule_job(bot.id, bot.token, bot.channel, bot.message), aio_loop
+            ),
+            'interval', seconds=bot.interval, id=str(bot.id), replace_existing=True
+        )
+
+def create_app():
+    """Return the configured Flask app."""
+    with app.app_context():
+        db.create_all()
+        initialize_jobs()
+    return app
+
+if __name__ == "__main__":
+    port = int(os.getenv("PORT", "5000"))
+    create_app().run(host="0.0.0.0", port=port, debug=True)

--- a/backend/app.py
+++ b/backend/app.py
@@ -13,6 +13,8 @@ from apscheduler.schedulers.background import BackgroundScheduler
 from apscheduler.executors.pool import ThreadPoolExecutor
 import websockets
 
+from app.routes import register_web
+
 # retry attempts for websocket messages
 MAX_RETRIES = 3
 
@@ -238,6 +240,7 @@ def create_app():
     with app.app_context():
         db.create_all()
         initialize_jobs()
+        register_web(app)
     return app
 
 if __name__ == "__main__":

--- a/backend/app.py
+++ b/backend/app.py
@@ -15,6 +15,7 @@ from apscheduler.executors.pool import ThreadPoolExecutor
 import websockets
 
 from app.routes import register_web
+from shared.kick import login as kick_login
 
 # retry attempts for websocket messages
 MAX_RETRIES = 3
@@ -146,6 +147,21 @@ def list_bots():
         }
         for b in bots
     ])
+
+
+@app.route('/login_kick', methods=['POST'])
+def login_kick():
+    """Return auth_token for provided Kick credentials."""
+    data = request.json
+    email = data.get('email')
+    password = data.get('password')
+    if not email or not password:
+        return jsonify({'error': 'email and password required'}), 400
+    try:
+        token = kick_login(email, password)
+    except Exception as exc:  # pragma: no cover - network failure
+        return jsonify({'error': str(exc)}), 502
+    return jsonify({'token': token})
 
 @app.route('/bots', methods=['POST'])
 def create_bot():

--- a/bots/bot_runner.py
+++ b/bots/bot_runner.py
@@ -1,0 +1,79 @@
+import argparse
+import json
+import time
+from pathlib import Path
+
+from selenium import webdriver
+from selenium.webdriver.common.by import By
+from selenium.webdriver.common.keys import Keys
+from selenium.webdriver.chrome.options import Options
+
+from shared.logger import logger
+
+DATA_FILE = Path(__file__).resolve().parent.parent / 'data.json'
+
+
+def load_config():
+    with open(DATA_FILE) as f:
+        return json.load(f)
+
+
+def init_driver(proxy: str | None = None):
+    opts = Options()
+    opts.add_argument('--start-maximized')
+    if proxy:
+        opts.add_argument(f'--proxy-server={proxy}')
+    driver = webdriver.Chrome(options=opts)
+    return driver
+
+
+def run_account(account: dict):
+    driver = init_driver(account.get('proxy'))
+    try:
+        logger.info('Logging in %s', account['email'])
+        driver.get('https://kick.com/login')
+        time.sleep(2)
+        driver.find_element(By.NAME, 'email').send_keys(account['email'])
+        driver.find_element(By.NAME, 'password').send_keys(account['password'])
+        driver.find_element(By.NAME, 'password').send_keys(Keys.RETURN)
+        time.sleep(5)  # wait for login
+
+        msg_file = Path('messages') / f"{account['id']}.txt"
+        messages = []
+        if msg_file.exists():
+            with open(msg_file) as f:
+                messages = [line.strip() for line in f if line.strip()]
+        if not messages:
+            messages = ['Hello from KickBot']
+
+        for msg in messages:
+            logger.info('Would send message for %s: %s', account['email'], msg)
+            # Placeholder for real message sending
+            time.sleep(1)
+    finally:
+        driver.quit()
+
+
+def main(group: str | None = None):
+    config = load_config()
+    accounts = {acc['id']: acc for acc in config['accounts']}
+    account_ids = []
+    if group:
+        grp = next((g for g in config['groups'] if g['name'] == group), None)
+        if not grp:
+            raise ValueError(f'Group {group} not found')
+        account_ids = grp['accounts']
+    else:
+        account_ids = list(accounts)
+
+    for aid in account_ids:
+        acc = accounts.get(aid)
+        if acc:
+            run_account(acc)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--group', help='Group name to run')
+    args = parser.parse_args()
+    main(args.group)

--- a/data.json
+++ b/data.json
@@ -1,0 +1,10 @@
+{
+  "accounts": [
+    {"id": 1, "email": "user1@example.com", "password": "pass1", "proxy": null},
+    {"id": 2, "email": "user2@example.com", "password": "pass2", "proxy": "http://proxy:8080"}
+  ],
+  "groups": [
+    {"name": "group1", "accounts": [1]},
+    {"name": "group2", "accounts": [1, 2]}
+  ]
+}

--- a/messages/1.txt
+++ b/messages/1.txt
@@ -1,0 +1,1 @@
+Hello Kick!

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+Flask
+Flask-SQLAlchemy
+APScheduler
+websockets
+selenium
+requests

--- a/run.py
+++ b/run.py
@@ -1,3 +1,5 @@
+"""Entry point for the KickBot dashboard and API server."""
+
 import os
 
 from backend.app import create_app

--- a/run.py
+++ b/run.py
@@ -3,10 +3,8 @@
 import os
 
 from backend.app import create_app
-from app.routes import register_web
 
 app = create_app()
-register_web(app)
 
 if __name__ == '__main__':
     debug = os.getenv('DEBUG', 'true').lower() == 'true'

--- a/run.py
+++ b/run.py
@@ -1,0 +1,20 @@
+import os
+
+from backend.app import create_app
+from app.routes import register_web
+
+app = create_app()
+register_web(app)
+
+if __name__ == '__main__':
+    debug = os.getenv('DEBUG', 'true').lower() == 'true'
+    port = int(os.getenv('PORT', '5000'))
+    host = os.getenv('HOST', '0.0.0.0')
+    try:
+        app.run(host=host, port=port, debug=debug)
+    except OSError as exc:
+        if exc.errno == 98:  # Address already in use
+            print(f"Port {port} in use, falling back to random port")
+            app.run(host=host, port=0, debug=debug)
+        else:
+            raise

--- a/scripts/add_bot.py
+++ b/scripts/add_bot.py
@@ -1,0 +1,30 @@
+import argparse
+import requests
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Create a bot via the Kick Multibot API")
+    parser.add_argument('--host', default='http://localhost:5000', help='Backend server URL')
+    parser.add_argument('--channel', required=True, help='Kick channel name')
+    parser.add_argument('--message', required=True, help='Message to send')
+    parser.add_argument('--interval', type=int, default=600, help='Send interval in seconds')
+    parser.add_argument('--token', required=True, help='Kick auth_token')
+    parser.add_argument('--inactive', action='store_true', help='Create bot as inactive')
+    args = parser.parse_args()
+
+    data = {
+        'channel': args.channel,
+        'message': args.message,
+        'interval': args.interval,
+        'token': args.token,
+        'active': not args.inactive,
+    }
+
+    resp = requests.post(f"{args.host}/bots", json=data)
+    resp.raise_for_status()
+    bot_id = resp.json().get('id')
+    print(f"Created bot with ID {bot_id}")
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/login_kick.py
+++ b/scripts/login_kick.py
@@ -1,22 +1,5 @@
 import argparse
-import requests
-
-LOGIN_URL = "https://kick.com/api/v1/login"
-
-
-def login(email: str, password: str) -> str:
-    """Attempt to log in and return auth_token."""
-    session = requests.Session()
-    resp = session.post(
-        LOGIN_URL,
-        json={"email": email, "password": password},
-        headers={"User-Agent": "Mozilla/5.0"},
-    )
-    resp.raise_for_status()
-    token = session.cookies.get("auth_token") or resp.json().get("token")
-    if not token:
-        raise RuntimeError("auth_token not found in response")
-    return token
+from shared.kick import login
 
 
 def main() -> None:

--- a/scripts/login_kick.py
+++ b/scripts/login_kick.py
@@ -1,0 +1,32 @@
+import argparse
+import requests
+
+LOGIN_URL = "https://kick.com/api/v1/login"
+
+
+def login(email: str, password: str) -> str:
+    """Attempt to log in and return auth_token."""
+    session = requests.Session()
+    resp = session.post(
+        LOGIN_URL,
+        json={"email": email, "password": password},
+        headers={"User-Agent": "Mozilla/5.0"},
+    )
+    resp.raise_for_status()
+    token = session.cookies.get("auth_token") or resp.json().get("token")
+    if not token:
+        raise RuntimeError("auth_token not found in response")
+    return token
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Login to Kick and print auth_token")
+    parser.add_argument("--email", required=True, help="Kick account email")
+    parser.add_argument("--password", required=True, help="Kick account password")
+    args = parser.parse_args()
+    token = login(args.email, args.password)
+    print(token)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_bot.py
+++ b/scripts/run_bot.py
@@ -1,0 +1,53 @@
+import argparse
+import asyncio
+import json
+import time
+import websockets
+
+MAX_RETRIES = 3
+KICK_URI = "wss://chat.kick.com"
+
+async def connect(token: str):
+    headers = {"Authorization": f"Bearer {token}"}
+    for attempt in range(1, MAX_RETRIES + 1):
+        try:
+            ws = await websockets.connect(
+                KICK_URI,
+                extra_headers=headers,
+                ping_interval=20,
+                ping_timeout=20,
+            )
+            return ws
+        except Exception as exc:
+            print(f"connect attempt {attempt} failed: {exc}")
+            await asyncio.sleep(2)
+    raise RuntimeError("Unable to connect to Kick")
+
+async def send_loop(channel: str, message: str, interval: int, token: str):
+    ws = await connect(token)
+    payload = json.dumps({"channel": channel, "message": message})
+    while True:
+        try:
+            await ws.send(payload)
+            print(f"{time.strftime('%Y-%m-%d %H:%M:%S')} sent to {channel}")
+        except Exception as exc:
+            print(f"send error: {exc}")
+            ws = await connect(token)
+            await ws.send(payload)
+        await asyncio.sleep(interval)
+
+def main():
+    parser = argparse.ArgumentParser(description="Simple Kick chat bot")
+    parser.add_argument("--channel", required=True, help="Kick channel name")
+    parser.add_argument("--message", required=True, help="Message to send")
+    parser.add_argument("--interval", type=int, default=600, help="Send interval in seconds")
+    parser.add_argument("--token", required=True, help="Kick auth_token")
+    args = parser.parse_args()
+
+    try:
+        asyncio.run(send_loop(args.channel, args.message, args.interval, args.token))
+    except KeyboardInterrupt:
+        print("Bot stopped")
+
+if __name__ == "__main__":
+    main()

--- a/shared/kick.py
+++ b/shared/kick.py
@@ -1,0 +1,18 @@
+import requests
+
+LOGIN_URL = "https://kick.com/api/v1/login"
+
+
+def login(email: str, password: str) -> str:
+    """Return auth_token for the given Kick credentials."""
+    session = requests.Session()
+    resp = session.post(
+        LOGIN_URL,
+        json={"email": email, "password": password},
+        headers={"User-Agent": "Mozilla/5.0"},
+    )
+    resp.raise_for_status()
+    token = session.cookies.get("auth_token") or resp.json().get("token")
+    if not token:
+        raise RuntimeError("auth_token not found in response")
+    return token

--- a/shared/logger.py
+++ b/shared/logger.py
@@ -1,0 +1,17 @@
+import logging
+import os
+from pathlib import Path
+
+LOG_DIR = Path(__file__).resolve().parent.parent / 'logs'
+LOG_DIR.mkdir(exist_ok=True)
+
+logging.basicConfig(
+    level=logging.INFO,
+    format='[%(asctime)s] %(levelname)s - %(message)s',
+    handlers=[
+        logging.FileHandler(LOG_DIR / 'kickbot.log'),
+        logging.StreamHandler()
+    ]
+)
+
+logger = logging.getLogger('kickbot')


### PR DESCRIPTION
## Summary
- create Flask login and dashboard to launch bot groups
- add Selenium bot runner and logging module
- store accounts and groups in `data.json`
- include Tailwind-based templates and simple README
- refine configuration and dashboard
- add alias so `url_for('dashboard')` works
- handle port conflicts when starting server
- refine dashboard assets
- document smoke test instructions

## Testing
- `python -m py_compile backend/app.py app/routes.py run.py bots/bot_runner.py scripts/add_bot.py scripts/login_kick.py scripts/run_bot.py shared/logger.py`
- `pip install -q -r requirements.txt`
- `python run.py & sleep 3; pkill -f run.py`


------
https://chatgpt.com/codex/tasks/task_e_68696a6d2a8883218deb0fc8038adb10