### PR TITLE
Add environment configuration for scheduler and WebSocket

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+instance/
+*.pyc
+*.db
+logs/

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Login at `http://localhost:5000/login` with **admin/admin**.
 ## Usage
 
 1. Create a group with a target channel and interval.
+   Group names must be unique; duplicate names will return an error.
 2. Add accounts pointing to that group. Each account may specify a messages file with text to send.
 3. Click **Start Scheduler** to begin automated sending. Bots run in batches and reconnect on failure.
 4. Use the command button next to a bot to send manual messages or request a screenshot.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,39 @@
-# kick-multibot-panel
+# KickBot Manager
+
+KickBot Manager is a lightweight dashboard for controlling chat bots on [Kick.com](https://kick.com). It combines a Flask backend with a simple Tailwind based frontend. Bots connect to Kick chat via WebSocket and can be scheduled or commanded from the web panel.
+
+## Features
+
+- Manage groups and accounts stored in a SQLite database
+- Start an asynchronous scheduler that sends messages from accounts to their group's target
+- Issue commands to running bots: send a message, check status, restart connection or capture a screenshot
+- View the last 50 log lines per bot
+
+## Setup
+
+Install dependencies and start the server:
+
+```bash
+pip install -r requirements.txt
+python run.py
+```
+
+Login at `http://localhost:5000/login` with **admin/admin**.
+
+### Environment variables
+
+- `PORT` – server port (default 5000)
+- `DB_PATH` – SQLite file (default `bots.db`)
+- `SECRET_KEY` – Flask secret key
+- `WORKERS` – scheduler thread pool size (default 50)
+- `MAX_INSTANCES` – maximum concurrent scheduled jobs (default 50)
+- `KICK_WS_URI` – WebSocket endpoint for Kick chat
+
+## Usage
+
+1. Create a group with a target channel and interval.
+2. Add accounts pointing to that group. Each account may specify a messages file with text to send.
+3. Click **Start Scheduler** to begin automated sending. Bots run in batches and reconnect on failure.
+4. Use the command button next to a bot to send manual messages or request a screenshot.
+
+Logs are stored under `logs/` with one file per bot.

--- a/app/routes.py
+++ b/app/routes.py
@@ -1,0 +1,44 @@
+from functools import wraps
+from flask import Blueprint, render_template, request, redirect, url_for, session, flash
+
+bp = Blueprint('panel', __name__)
+
+def login_required(func):
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        if 'user' not in session:
+            return redirect(url_for('panel.login'))
+        return func(*args, **kwargs)
+    return wrapper
+
+@bp.route('/')
+def index():
+    if 'user' in session:
+        return redirect(url_for('panel.dashboard'))
+    return redirect(url_for('panel.login'))
+
+@bp.route('/login', methods=['GET', 'POST'])
+def login():
+    if request.method == 'POST':
+        if request.form.get('username') == 'admin' and request.form.get('password') == 'admin':
+            session['user'] = 'admin'
+            return redirect(url_for('panel.dashboard'))
+        flash('Invalid credentials')
+    return render_template('login.html')
+
+@bp.route('/logout')
+def logout():
+    session.pop('user', None)
+    return redirect(url_for('panel.login'))
+
+@bp.route('/dashboard')
+@login_required
+def dashboard():
+    return render_template('dashboard.html')
+
+
+def register_web(app):
+    """Register blueprint with the given Flask app."""
+    app.register_blueprint(bp)
+    # provide an alias so url_for('dashboard') works
+    app.add_url_rule('/dashboard', 'dashboard', dashboard)

--- a/app/static/main.js
+++ b/app/static/main.js
@@ -62,11 +62,14 @@ document.getElementById('groupForm').addEventListener('submit', async e => {
     target: document.getElementById('g-target').value,
     interval: parseInt(document.getElementById('g-interval').value, 10)
   };
-  await api('/dashboard/api/groups', {
+  const res = await api('/dashboard/api/groups', {
     method: 'POST',
     headers: {'Content-Type': 'application/json'},
     body: JSON.stringify(data)
   });
+  if (res && res.error) {
+    alert(res.error);
+  }
 });
 
 document.getElementById('accountForm').addEventListener('submit', async e => {
@@ -78,11 +81,14 @@ document.getElementById('accountForm').addEventListener('submit', async e => {
     messages_file: document.getElementById('a-msg').value,
     group_id: parseInt(document.getElementById('a-group').value, 10)
   };
-  await api('/dashboard/api/accounts', {
+  const res = await api('/dashboard/api/accounts', {
     method: 'POST',
     headers: {'Content-Type': 'application/json'},
     body: JSON.stringify(data)
   });
+  if (res && res.error) {
+    alert(res.error);
+  }
 });
 
 loadBots();

--- a/app/static/main.js
+++ b/app/static/main.js
@@ -1,0 +1,89 @@
+async function api(url, opts = {}) {
+  const res = await fetch(url, opts).catch(() => null);
+  if (!res) return null;
+  return res.json();
+}
+
+async function loadBots() {
+  const bots = await api('/dashboard/api/bots');
+  if (!bots) return;
+  const container = document.getElementById('bots');
+  container.innerHTML = '';
+  bots.forEach(b => {
+    const div = document.createElement('div');
+    div.className = 'border p-2';
+    div.innerHTML = `ID ${b.id} (${b.username}) - ${b.status} ` +
+      `<button onclick="openCmd(${b.id})" class="bg-blue-500 text-white px-1">Cmd</button>`;
+    container.appendChild(div);
+  });
+}
+
+async function startScheduler() {
+  await api('/dashboard/api/scheduler/start', {method: 'POST'});
+}
+
+function openCmd(id) {
+  document.getElementById('cmd-id').value = id;
+  document.getElementById('cmdDialog').showModal();
+}
+
+function closeCmd() {
+  document.getElementById('cmdDialog').close();
+}
+
+async function fetchLogs(id) {
+  const logs = await api(`/dashboard/api/bots/${id}/logs`);
+  if (!logs) return;
+  document.getElementById('logBox').textContent = logs.join('\n');
+}
+
+// Forms
+
+document.getElementById('cmdForm').addEventListener('submit', async e => {
+  e.preventDefault();
+  const id = document.getElementById('cmd-id').value;
+  const cmd = document.getElementById('cmd-type').value;
+  const args = document.getElementById('cmd-args').value;
+  await api(`/dashboard/api/bots/${id}/command`, {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify({cmd: cmd, args: {message: args}})
+  });
+  closeCmd();
+  fetchLogs(id);
+});
+
+// TODO: simple forms for groups and accounts (not fully implemented)
+
+document.getElementById('groupForm').addEventListener('submit', async e => {
+  e.preventDefault();
+  const data = {
+    name: document.getElementById('g-name').value,
+    target: document.getElementById('g-target').value,
+    interval: parseInt(document.getElementById('g-interval').value, 10)
+  };
+  await api('/dashboard/api/groups', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify(data)
+  });
+});
+
+document.getElementById('accountForm').addEventListener('submit', async e => {
+  e.preventDefault();
+  const data = {
+    username: document.getElementById('a-user').value,
+    password: document.getElementById('a-pass').value,
+    proxy: document.getElementById('a-proxy').value,
+    messages_file: document.getElementById('a-msg').value,
+    group_id: parseInt(document.getElementById('a-group').value, 10)
+  };
+  await api('/dashboard/api/accounts', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify(data)
+  });
+});
+
+loadBots();
+setInterval(loadBots, 5000);

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -1,0 +1,8 @@
+table th, table td {
+  border: 1px solid #ddd;
+  padding: 4px 8px;
+}
+
+table th {
+  background-color: #f3f4f6;
+}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>{% block title %}KickBot{% endblock %}</title>
+  <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
+</head>
+<body class="p-4">
+  {% with messages = get_flashed_messages() %}
+    {% if messages %}
+      <ul class="mb-4">
+        {% for m in messages %}
+          <li class="bg-green-200 p-2 mb-2">{{ m }}</li>
+        {% endfor %}
+      </ul>
+    {% endif %}
+  {% endwith %}
+  {% if session.get('user') %}
+    <a href="{{ url_for('panel.logout') }}" class="text-blue-600 underline">Logout</a>
+  {% endif %}
+  {% block content %}{% endblock %}
+</body>
+</html>

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -1,0 +1,54 @@
+{% extends 'base.html' %}
+{% block title %}Dashboard{% endblock %}
+{% block content %}
+<h1 class="text-xl mb-4">KickBot Manager</h1>
+<section class="mb-6">
+  <h2 class="font-bold">Groups</h2>
+  <form id="groupForm" class="space-y-2 mb-4">
+    Name: <input id="g-name" class="border" required>
+    Target: <input id="g-target" class="border" required>
+    Interval: <input id="g-interval" type="number" value="600" class="border" required>
+    <button class="bg-green-600 text-white px-2 py-1" type="submit">Create</button>
+  </form>
+  <table id="groupTable" class="w-full border-collapse"></table>
+</section>
+<section class="mb-6">
+  <h2 class="font-bold">Accounts</h2>
+  <form id="accountForm" class="space-y-2 mb-4">
+    Username: <input id="a-user" class="border" required>
+    Password: <input id="a-pass" type="password" class="border" required>
+    Proxy: <input id="a-proxy" class="border">
+    Messages file: <input id="a-msg" class="border">
+    Group ID: <input id="a-group" type="number" class="border" required>
+    <button class="bg-green-600 text-white px-2 py-1" type="submit">Create</button>
+  </form>
+  <table id="accountTable" class="w-full border-collapse"></table>
+</section>
+<section>
+  <h2 class="font-bold">Bots</h2>
+  <button onclick="startScheduler()" class="bg-blue-500 text-white px-2 py-1 mb-2">Start Scheduler</button>
+  <div id="bots" class="space-y-2"></div>
+</section>
+
+<dialog id="cmdDialog">
+  <form id="cmdForm" class="space-y-2">
+    <input type="hidden" id="cmd-id">
+    <select id="cmd-type" class="border">
+      <option value="send_message">Send message</option>
+      <option value="status_check">Status</option>
+      <option value="restart">Restart</option>
+      <option value="screenshot">Screenshot</option>
+    </select>
+    Args: <input id="cmd-args" class="border" placeholder="message text">
+    <button class="bg-blue-500 text-white px-2 py-1" type="submit">Run</button>
+    <button type="button" onclick="closeCmd()">Cancel</button>
+  </form>
+</dialog>
+
+<section class="mt-6">
+  <h2 class="font-bold">Logs</h2>
+  <pre id="logBox" class="bg-gray-100 p-2 h-64 overflow-auto"></pre>
+</section>
+
+<script src="{{ url_for('static', filename='main.js') }}"></script>
+{% endblock %}

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -1,0 +1,10 @@
+{% extends 'base.html' %}
+{% block title %}Login{% endblock %}
+{% block content %}
+<h1 class="text-xl mb-4">Login</h1>
+<form method="post" class="space-y-2">
+  <input type="text" name="username" placeholder="Username" class="border p-2 w-full" required>
+  <input type="password" name="password" placeholder="Password" class="border p-2 w-full" required>
+  <button type="submit" class="bg-blue-500 text-white px-4 py-2">Login</button>
+</form>
+{% endblock %}

--- a/backend/app.py
+++ b/backend/app.py
@@ -9,6 +9,7 @@ from threading import Thread
 from flask import Flask, jsonify, request
 from flask_sqlalchemy import SQLAlchemy
 from sqlalchemy import text
+from sqlalchemy.exc import IntegrityError
 from apscheduler.schedulers.background import BackgroundScheduler
 from apscheduler.executors.pool import ThreadPoolExecutor
 import websockets
@@ -73,7 +74,11 @@ def api_groups():
         data = request.json
         g = Group(name=data['name'], target=data['target'], interval=data['interval'])
         db.session.add(g)
-        db.session.commit()
+        try:
+            db.session.commit()
+        except IntegrityError:
+            db.session.rollback()
+            return jsonify({'error': 'group name must be unique'}), 400
         return jsonify({'id': g.id})
     return jsonify([{ 'id': g.id, 'name': g.name, 'target': g.target, 'interval': g.interval } for g in Group.query.all()])
 
@@ -90,7 +95,11 @@ def api_accounts():
             group_id=data['group_id'],
         )
         db.session.add(acc)
-        db.session.commit()
+        try:
+            db.session.commit()
+        except IntegrityError:
+            db.session.rollback()
+            return jsonify({'error': 'could not create account'}), 400
         return jsonify({'id': acc.id})
     return jsonify([{ 'id': a.id, 'username': a.username, 'group_id': a.group_id } for a in Account.query.all()])
 

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,0 +1,218 @@
+"""KickBot Manager backend"""
+
+import asyncio
+import os
+from datetime import datetime
+from pathlib import Path
+from threading import Thread
+
+from flask import Flask, jsonify, request
+from flask_sqlalchemy import SQLAlchemy
+from sqlalchemy import text
+from apscheduler.schedulers.background import BackgroundScheduler
+from apscheduler.executors.pool import ThreadPoolExecutor
+import websockets
+
+from app.routes import register_web
+from bots.instance import BotInstance
+from shared.logger import logger
+
+BASE_DIR = Path(__file__).resolve().parent
+
+app = Flask(
+    __name__,
+    static_folder=str(BASE_DIR.parent / "app" / "static"),
+    template_folder=str(BASE_DIR.parent / "app" / "templates"),
+)
+app.config["SECRET_KEY"] = os.getenv("SECRET_KEY", "change-me")
+DB_PATH = os.getenv("DB_PATH", "bots.db")
+app.config["SQLALCHEMY_DATABASE_URI"] = f"sqlite:///{DB_PATH}"
+app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
+
+# Database
+
+db = SQLAlchemy(app)
+
+class Group(db.Model):
+    __tablename__ = 'groups'
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(80), unique=True, nullable=False)
+    target = db.Column(db.String(80), nullable=False)
+    interval = db.Column(db.Integer, default=600)
+
+class Account(db.Model):
+    __tablename__ = 'accounts'
+    id = db.Column(db.Integer, primary_key=True)
+    username = db.Column(db.String(120), nullable=False)
+    password = db.Column(db.String(120), nullable=False)
+    proxy = db.Column(db.String(200))
+    messages_file = db.Column(db.String(200))
+    group_id = db.Column(db.Integer, db.ForeignKey("groups.id"))
+
+class Log(db.Model):
+    __tablename__ = 'logs'
+    id = db.Column(db.Integer, primary_key=True)
+    account_id = db.Column(db.Integer, db.ForeignKey("accounts.id"))
+    timestamp = db.Column(db.DateTime, default=datetime.utcnow)
+    message = db.Column(db.String(200))
+
+bots: dict[int, BotInstance] = {}
+
+WORKERS = int(os.getenv("WORKERS", "50"))
+MAX_INSTANCES = int(os.getenv("MAX_INSTANCES", "50"))
+
+sched = BackgroundScheduler(
+    executors={"default": ThreadPoolExecutor(max_workers=WORKERS)},
+    job_defaults={"max_instances": MAX_INSTANCES},
+)
+
+
+@app.route('/dashboard/api/groups', methods=['POST', 'GET'])
+def api_groups():
+    if request.method == 'POST':
+        data = request.json
+        g = Group(name=data['name'], target=data['target'], interval=data['interval'])
+        db.session.add(g)
+        db.session.commit()
+        return jsonify({'id': g.id})
+    return jsonify([{ 'id': g.id, 'name': g.name, 'target': g.target, 'interval': g.interval } for g in Group.query.all()])
+
+
+@app.route('/dashboard/api/accounts', methods=['POST', 'GET'])
+def api_accounts():
+    if request.method == 'POST':
+        data = request.json
+        acc = Account(
+            username=data['username'],
+            password=data['password'],
+            proxy=data.get('proxy'),
+            messages_file=data.get('messages_file'),
+            group_id=data['group_id'],
+        )
+        db.session.add(acc)
+        db.session.commit()
+        return jsonify({'id': acc.id})
+    return jsonify([{ 'id': a.id, 'username': a.username, 'group_id': a.group_id } for a in Account.query.all()])
+
+
+async def send_job(account_id: int):
+    account = Account.query.get(account_id)
+    if not account:
+        return
+    group = Group.query.get(account.group_id)
+    if not group:
+        return
+    if account_id not in bots:
+        bots[account_id] = BotInstance(account, group)
+        bots[account_id].login()
+    bot = bots[account_id]
+    msg_path = Path(account.messages_file or "").expanduser()
+    message = "Hello from KickBot"
+    if msg_path.is_file():
+        with open(msg_path) as fh:
+            line = fh.readline().strip()
+            if line:
+                message = line
+    await bot.send_message(message)
+    with app.app_context():
+        log = Log(account_id=account_id, message=message)
+        db.session.add(log)
+        db.session.commit()
+
+
+def start_async_loop(loop):
+    asyncio.set_event_loop(loop)
+    loop.run_forever()
+
+
+aio_loop = asyncio.new_event_loop()
+thread = Thread(target=start_async_loop, args=(aio_loop,))
+thread.daemon = True
+thread.start()
+
+
+def schedule_all():
+    """Schedule message sending for all accounts."""
+    sched.remove_all_jobs()
+    for acc in Account.query.all():
+        group = Group.query.get(acc.group_id)
+        if group:
+            sched.add_job(
+                lambda aid=acc.id: asyncio.run_coroutine_threadsafe(
+                    send_job(aid), aio_loop
+                ),
+                "interval",
+                seconds=group.interval,
+                id=str(acc.id),
+                replace_existing=True,
+            )
+
+
+@app.route("/dashboard/api/scheduler/start", methods=["POST"])
+def api_start_sched():
+    if not sched.running:
+        sched.start()
+    schedule_all()
+    return jsonify({"status": "started"})
+
+
+@app.route("/dashboard/api/bots", methods=["GET"])
+def api_list_bots():
+    data = []
+    for acc in Account.query.all():
+        status = "offline"
+        bot = bots.get(acc.id)
+        if bot and bot.ws and not bot.ws.closed:
+            status = "online"
+        data.append({"id": acc.id, "username": acc.username, "status": status})
+    return jsonify(data)
+
+
+@app.route("/dashboard/api/bots/<int:bid>/command", methods=["POST"])
+def api_bot_cmd(bid):
+    cmd = request.json.get("cmd")
+    args = request.json.get("args", {})
+    bot = bots.get(bid)
+    if not bot:
+        return jsonify({"error": "bot not running"}), 404
+    async def run():
+        if cmd == "send_message":
+            await bot.send_message(args.get("message", ""))
+        elif cmd == "status_check":
+            return await bot.status_check()
+        elif cmd == "restart":
+            await bot.restart()
+        elif cmd == "screenshot":
+            bot.screenshot()
+    fut = asyncio.run_coroutine_threadsafe(run(), aio_loop)
+    fut.result()
+    return jsonify({"status": "ok"})
+
+
+@app.route("/dashboard/api/bots/<int:bid>/logs", methods=["GET"])
+def api_bot_logs(bid):
+    path = Path("logs") / f"bot_{bid}.log"
+    if not path.exists():
+        return jsonify([])
+    lines = path.read_text().splitlines()[-50:]
+    return jsonify(lines)
+
+
+def init_db():
+    db.create_all()
+    register_web(app)
+    with db.engine.begin() as conn:
+        conn.execute(text("CREATE TABLE IF NOT EXISTS groups (id INTEGER PRIMARY KEY, name VARCHAR(80) UNIQUE, target VARCHAR(80), interval INTEGER)"))
+        conn.execute(text("CREATE TABLE IF NOT EXISTS accounts (id INTEGER PRIMARY KEY, username VARCHAR(120), password VARCHAR(120), proxy VARCHAR(200), messages_file VARCHAR(200), group_id INTEGER)"))
+        conn.execute(text("CREATE TABLE IF NOT EXISTS logs (id INTEGER PRIMARY KEY, account_id INTEGER, timestamp DATETIME, message VARCHAR(200))"))
+
+
+def create_app():
+    with app.app_context():
+        init_db()
+    return app
+
+
+if __name__ == "__main__":
+    port = int(os.getenv("PORT", "5000"))
+    create_app().run(host="0.0.0.0", port=port, debug=os.getenv("DEBUG", "true").lower() == "true")

--- a/bots/bot_runner.py
+++ b/bots/bot_runner.py
@@ -1,0 +1,79 @@
+import argparse
+import json
+import time
+from pathlib import Path
+
+from selenium import webdriver
+from selenium.webdriver.common.by import By
+from selenium.webdriver.common.keys import Keys
+from selenium.webdriver.chrome.options import Options
+
+from shared.logger import logger
+
+DATA_FILE = Path(__file__).resolve().parent.parent / 'data.json'
+
+
+def load_config():
+    with open(DATA_FILE) as f:
+        return json.load(f)
+
+
+def init_driver(proxy: str | None = None):
+    opts = Options()
+    opts.add_argument('--start-maximized')
+    if proxy:
+        opts.add_argument(f'--proxy-server={proxy}')
+    driver = webdriver.Chrome(options=opts)
+    return driver
+
+
+def run_account(account: dict):
+    driver = init_driver(account.get('proxy'))
+    try:
+        logger.info('Logging in %s', account['email'])
+        driver.get('https://kick.com/login')
+        time.sleep(2)
+        driver.find_element(By.NAME, 'email').send_keys(account['email'])
+        driver.find_element(By.NAME, 'password').send_keys(account['password'])
+        driver.find_element(By.NAME, 'password').send_keys(Keys.RETURN)
+        time.sleep(5)  # wait for login
+
+        msg_file = Path('messages') / f"{account['id']}.txt"
+        messages = []
+        if msg_file.exists():
+            with open(msg_file) as f:
+                messages = [line.strip() for line in f if line.strip()]
+        if not messages:
+            messages = ['Hello from KickBot']
+
+        for msg in messages:
+            logger.info('Would send message for %s: %s', account['email'], msg)
+            # Placeholder for real message sending
+            time.sleep(1)
+    finally:
+        driver.quit()
+
+
+def main(group: str | None = None):
+    config = load_config()
+    accounts = {acc['id']: acc for acc in config['accounts']}
+    account_ids = []
+    if group:
+        grp = next((g for g in config['groups'] if g['name'] == group), None)
+        if not grp:
+            raise ValueError(f'Group {group} not found')
+        account_ids = grp['accounts']
+    else:
+        account_ids = list(accounts)
+
+    for aid in account_ids:
+        acc = accounts.get(aid)
+        if acc:
+            run_account(acc)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--group', help='Group name to run')
+    args = parser.parse_args()
+    main(args.group)

--- a/bots/instance.py
+++ b/bots/instance.py
@@ -1,0 +1,104 @@
+import asyncio
+import os
+from pathlib import Path
+from typing import Optional
+
+from selenium import webdriver
+from selenium.webdriver.common.by import By
+from selenium.webdriver.common.keys import Keys
+from selenium.webdriver.chrome.options import Options
+import websockets
+
+from shared.logger import get_bot_logger
+
+WS_URI = os.getenv("KICK_WS_URI", "wss://chat.kick.com/channel/{target}")
+
+class BotInstance:
+    """Represents a single Kick bot account."""
+
+    def __init__(self, account, group):
+        self.account = account
+        self.group = group
+        self.driver: Optional[webdriver.Chrome] = None
+        self.ws: Optional[websockets.WebSocketClientProtocol] = None
+        self.log = get_bot_logger(account.id)
+        self._lock = asyncio.Lock()
+
+    def _init_driver(self):
+        opts = Options()
+        opts.add_argument('--start-maximized')
+        if self.account.proxy:
+            opts.add_argument(f'--proxy-server={self.account.proxy}')
+        self.driver = webdriver.Chrome(options=opts)
+
+    async def connect(self):
+        if self.ws and not self.ws.closed:
+            return
+        url = WS_URI.format(target=self.group.target)
+        for _ in range(3):
+            try:
+                self.ws = await websockets.connect(url, ping_interval=20, ping_timeout=20)
+                return
+            except Exception as exc:
+                self.log.warning('connect error: %s', exc)
+                await asyncio.sleep(5)
+        raise ConnectionError('Unable to connect')
+
+    def login(self):
+        if self.driver is None:
+            self._init_driver()
+        d = self.driver
+        d.get('https://kick.com/login')
+        try:
+            accept = d.find_element(By.CSS_SELECTOR, '[aria-label="Accept cookies"]')
+            accept.click()
+        except Exception:
+            pass
+        # try several selectors for username and password
+        def find_input(cands):
+            for c in cands:
+                els = d.find_elements(By.CSS_SELECTOR, c)
+                if els:
+                    return els[0]
+            return None
+        user = find_input(['input[name=emailOrUsername]', 'input[type=email]', 'input[placeholder*=mail]'])
+        pwd = find_input(['input[name=password]', 'input[type=password]'])
+        login_btn = find_input(['button[data-testid="login"]', 'button[type=submit]'])
+        if user and pwd:
+            user.send_keys(self.account.username)
+            pwd.send_keys(self.account.password)
+            if login_btn:
+                login_btn.click()
+            else:
+                pwd.send_keys(Keys.RETURN)
+
+    async def send_message(self, message: str):
+        for attempt in range(2):
+            try:
+                await self.connect()
+                async with self._lock:
+                    await self.ws.send(message)
+                self.log.info('sent message: %s', message)
+                return
+            except Exception as exc:
+                self.log.warning('send error: %s', exc)
+                await self.restart()
+        raise ConnectionError('send failed after reconnect')
+
+    async def status_check(self):
+        await self.connect()
+        return not self.ws.closed
+
+    async def restart(self):
+        if self.ws:
+            await self.ws.close()
+        await self.connect()
+
+    def screenshot(self, folder='screenshots'):
+        Path(folder).mkdir(exist_ok=True)
+        path = Path(folder) / f'{self.account.id}.png'
+        if self.driver:
+            self.driver.save_screenshot(str(path))
+            self.log.info('saved screenshot %s', path)
+        return str(path)
+

--- a/data.json
+++ b/data.json
@@ -1,0 +1,10 @@
+{
+  "accounts": [
+    {"id": 1, "email": "user1@example.com", "password": "pass1", "proxy": null},
+    {"id": 2, "email": "user2@example.com", "password": "pass2", "proxy": "http://proxy:8080"}
+  ],
+  "groups": [
+    {"name": "group1", "accounts": [1]},
+    {"name": "group2", "accounts": [1, 2]}
+  ]
+}

--- a/messages/1.txt
+++ b/messages/1.txt
@@ -1,0 +1,1 @@
+Hello Kick!

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+Flask
+Flask-SQLAlchemy
+APScheduler
+websockets
+selenium
+requests

--- a/run.py
+++ b/run.py
@@ -1,0 +1,20 @@
+"""Entry point for the KickBot dashboard and API server."""
+
+import os
+
+from backend.app import create_app
+
+app = create_app()
+
+if __name__ == '__main__':
+    debug = os.getenv('DEBUG', 'true').lower() == 'true'
+    port = int(os.getenv('PORT', '5000'))
+    host = os.getenv('HOST', '0.0.0.0')
+    try:
+        app.run(host=host, port=port, debug=debug)
+    except OSError as exc:
+        if exc.errno == 98:  # Address already in use
+            print(f"Port {port} in use, falling back to random port")
+            app.run(host=host, port=0, debug=debug)
+        else:
+            raise

--- a/scripts/add_bot.py
+++ b/scripts/add_bot.py
@@ -1,0 +1,30 @@
+import argparse
+import requests
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Create a bot via the Kick Multibot API")
+    parser.add_argument('--host', default='http://localhost:5000', help='Backend server URL')
+    parser.add_argument('--channel', required=True, help='Kick channel name')
+    parser.add_argument('--message', required=True, help='Message to send')
+    parser.add_argument('--interval', type=int, default=600, help='Send interval in seconds')
+    parser.add_argument('--token', required=True, help='Kick auth_token')
+    parser.add_argument('--inactive', action='store_true', help='Create bot as inactive')
+    args = parser.parse_args()
+
+    data = {
+        'channel': args.channel,
+        'message': args.message,
+        'interval': args.interval,
+        'token': args.token,
+        'active': not args.inactive,
+    }
+
+    resp = requests.post(f"{args.host}/bots", json=data)
+    resp.raise_for_status()
+    bot_id = resp.json().get('id')
+    print(f"Created bot with ID {bot_id}")
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/login_kick.py
+++ b/scripts/login_kick.py
@@ -1,0 +1,15 @@
+import argparse
+from shared.kick import login
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Login to Kick and print auth_token")
+    parser.add_argument("--email", required=True, help="Kick account email")
+    parser.add_argument("--password", required=True, help="Kick account password")
+    args = parser.parse_args()
+    token = login(args.email, args.password)
+    print(token)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_bot.py
+++ b/scripts/run_bot.py
@@ -1,0 +1,54 @@
+import argparse
+import asyncio
+import json
+import os
+import time
+import websockets
+
+MAX_RETRIES = 3
+KICK_URI = os.getenv("KICK_WS_URI", "wss://chat.kick.com")
+
+async def connect(token: str):
+    headers = {"Authorization": f"Bearer {token}"}
+    for attempt in range(1, MAX_RETRIES + 1):
+        try:
+            ws = await websockets.connect(
+                KICK_URI,
+                extra_headers=headers,
+                ping_interval=20,
+                ping_timeout=20,
+            )
+            return ws
+        except Exception as exc:
+            print(f"connect attempt {attempt} failed: {exc}")
+            await asyncio.sleep(2)
+    raise RuntimeError("Unable to connect to Kick")
+
+async def send_loop(channel: str, message: str, interval: int, token: str):
+    ws = await connect(token)
+    payload = json.dumps({"channel": channel, "message": message})
+    while True:
+        try:
+            await ws.send(payload)
+            print(f"{time.strftime('%Y-%m-%d %H:%M:%S')} sent to {channel}")
+        except Exception as exc:
+            print(f"send error: {exc}")
+            ws = await connect(token)
+            await ws.send(payload)
+        await asyncio.sleep(interval)
+
+def main():
+    parser = argparse.ArgumentParser(description="Simple Kick chat bot")
+    parser.add_argument("--channel", required=True, help="Kick channel name")
+    parser.add_argument("--message", required=True, help="Message to send")
+    parser.add_argument("--interval", type=int, default=600, help="Send interval in seconds")
+    parser.add_argument("--token", required=True, help="Kick auth_token")
+    args = parser.parse_args()
+
+    try:
+        asyncio.run(send_loop(args.channel, args.message, args.interval, args.token))
+    except KeyboardInterrupt:
+        print("Bot stopped")
+
+if __name__ == "__main__":
+    main()

--- a/shared/kick.py
+++ b/shared/kick.py
@@ -1,0 +1,18 @@
+import requests
+
+LOGIN_URL = "https://kick.com/api/v1/login"
+
+
+def login(email: str, password: str) -> str:
+    """Return auth_token for the given Kick credentials."""
+    session = requests.Session()
+    resp = session.post(
+        LOGIN_URL,
+        json={"email": email, "password": password},
+        headers={"User-Agent": "Mozilla/5.0"},
+    )
+    resp.raise_for_status()
+    token = session.cookies.get("auth_token") or resp.json().get("token")
+    if not token:
+        raise RuntimeError("auth_token not found in response")
+    return token

--- a/shared/logger.py
+++ b/shared/logger.py
@@ -1,0 +1,27 @@
+import logging
+import os
+from pathlib import Path
+
+LOG_DIR = Path(__file__).resolve().parent.parent / 'logs'
+LOG_DIR.mkdir(exist_ok=True)
+
+logging.basicConfig(
+    level=logging.INFO,
+    format='[%(asctime)s] %(levelname)s - %(message)s',
+    handlers=[
+        logging.FileHandler(LOG_DIR / 'kickbot.log'),
+        logging.StreamHandler()
+    ]
+)
+
+logger = logging.getLogger('kickbot')
+
+def get_bot_logger(bot_id: int) -> logging.Logger:
+    """Return a logger that writes to logs/bot_<id>.log."""
+    name = f"bot_{bot_id}"
+    bot_logger = logging.getLogger(name)
+    if not bot_logger.handlers:
+        fh = logging.FileHandler(LOG_DIR / f"bot_{bot_id}.log")
+        bot_logger.addHandler(fh)
+        bot_logger.setLevel(logging.INFO)
+    return bot_logger


### PR DESCRIPTION
## Summary
- make scheduler worker counts configurable via environment variables
- allow overriding Kick WebSocket URI with `KICK_WS_URI`
- retry sending messages if a connection error occurs
- document new environment variables

## Testing
- `python -m py_compile backend/app.py app/routes.py run.py bots/bot_runner.py bots/instance.py scripts/add_bot.py scripts/login_kick.py scripts/run_bot.py shared/logger.py shared/kick.py`
- `pip install -q -r requirements.txt`
- `python run.py & sleep 3; pkill -f run.py`


------
https://chatgpt.com/codex/tasks/task_e_68696a6d2a8883218deb0fc8038adb10