### PR TITLE
Fix socketio serialization in RQ job

### DIFF
--- a/app/static/main.js
+++ b/app/static/main.js
@@ -127,11 +127,13 @@ async function loadAccounts() {
   if (!data) return;
   const accs = data.items || data;
   const table = document.getElementById('accountTable');
-  table.innerHTML = '<tr><th>ID</th><th>User</th><th>Group</th></tr>';
+  table.innerHTML = '<thead class="bg-gray-100 font-bold"><tr><th class="border px-2">ID</th><th class="border px-2">User</th><th class="border px-2">Group</th></tr></thead><tbody></tbody>';
+  const tbody = table.querySelector('tbody');
   accs.forEach(a => {
     const row = document.createElement('tr');
+    row.className = 'odd:bg-gray-50';
     row.innerHTML = `<td class="border px-2">${a.id}</td><td class="border px-2">${a.username}</td><td class="border px-2">${a.group_id}</td>`;
-    table.appendChild(row);
+    tbody.appendChild(row);
   });
 }
 
@@ -145,15 +147,17 @@ async function loadBots() {
   container.innerHTML = '';
   bots.forEach(b => {
     const div = document.createElement('div');
-    let color = 'bg-red-200';
-    if (b.status === 'online') color = 'bg-green-200';
-    else if (b.status === 'queued') color = 'bg-yellow-200';
-    div.className = `${color} p-2 space-x-1`;
-    div.innerHTML = `ID ${b.id} (${b.username}) - ${b.status}
-      <button onclick="startBot(${b.id})" class="bg-green-500 text-white px-1">Start</button>
-      <button onclick="stopBot(${b.id})" class="bg-red-500 text-white px-1">Stop</button>
-      <button onclick="openCmd(${b.id})" class="bg-blue-500 text-white px-1">Cmd</button>
-      <button onclick="fetchLogs(${b.id})" class="text-sm underline">Logs</button>`;
+    div.className = 'bg-gray-50 rounded shadow p-2 flex justify-between items-center';
+    let color = 'bg-red-500';
+    if (b.status === 'online') color = 'bg-green-500';
+    const badge = `<span class="text-white ${color} text-xs px-2 py-1 rounded">${b.status}</span>`;
+    div.innerHTML = `<span>ID ${b.id} (${b.username}) ${badge}</span>
+      <span class="space-x-1">
+        <button onclick="startBot(${b.id})" class="bg-green-600 hover:bg-green-700 text-white px-2 py-1 rounded text-xs">Start</button>
+        <button onclick="stopBot(${b.id})" class="bg-red-600 hover:bg-red-700 text-white px-2 py-1 rounded text-xs">Stop</button>
+        <button onclick="openCmd(${b.id})" class="bg-blue-600 hover:bg-blue-700 text-white px-2 py-1 rounded text-xs">Cmd</button>
+        <button onclick="fetchLogs(${b.id})" class="underline text-xs">Logs</button>
+      </span>`;
     container.appendChild(div);
   });
 }
@@ -195,7 +199,9 @@ async function fetchLogs(id) {
   async function load() {
     const lines = await api(`/dashboard/api/bots/${id}/logs`);
     if (lines) {
-      document.getElementById('logBox').textContent = lines.join('\n');
+      const box = document.getElementById('logBox');
+      box.textContent = lines.join('\n');
+      box.scrollTop = box.scrollHeight;
     }
   }
   await load();

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -2,37 +2,44 @@
 {% block title %}Dashboard{% endblock %}
 {% block content %}
 <h1 class="text-xl mb-4">KickBot Manager</h1>
-<div class="flex flex-col md:flex-row">
-  <aside class="md:w-1/4 p-2 bg-gray-50" id="sidebar">
+<div class="grid gap-4 md:grid-cols-2" id="mainArea">
+  <section class="bg-white rounded shadow p-4 md:block hidden" id="sidebar">
     <div class="flex justify-between items-center mb-2">
-      <span class="font-bold">Groups</span>
-      <button id="addGroupBtn" class="bg-green-600 text-white px-2 py-1 text-sm">Add</button>
+      <h2 class="text-lg font-bold">Groups</h2>
+      <button id="addGroupBtn" class="bg-green-600 hover:bg-green-700 text-white px-3 py-1 rounded text-sm">Add</button>
     </div>
-    <input id="groupSearch" class="border w-full mb-2" placeholder="Search groups">
+    <input id="groupSearch" class="border w-full mb-2 p-1" placeholder="Search groups">
     <ul id="groupList" class="space-y-1"></ul>
-  </aside>
-  <main class="md:flex-1 p-2" id="mainArea">
-    <button onclick="syncPush()" class="bg-gray-500 text-white px-2 py-1 mb-2">Sync Now</button>
+  </section>
+
+  <section class="bg-white rounded shadow p-4" id="accountsSection">
     <div class="flex justify-between items-center mb-2">
-      <span class="font-bold">Accounts</span>
-      <button id="addAccountBtn" class="bg-green-600 text-white px-2 py-1 text-sm">Add</button>
+      <h2 class="text-lg font-bold">Accounts</h2>
+      <button id="addAccountBtn" class="bg-green-600 hover:bg-green-700 text-white px-3 py-1 rounded text-sm">Add</button>
     </div>
-    <input id="accountSearch" class="border w-full mb-2" placeholder="Search accounts">
-    <table id="accountTable" class="w-full border-collapse mb-4"></table>
-    <section class="mb-4">
-      <h2 class="font-bold">Bots</h2>
-      <button onclick="startScheduler()" class="bg-blue-500 text-white px-2 py-1 mb-2">Start Scheduler</button>
-      <input id="botSearch" class="border w-full mb-2" placeholder="Search bots">
-      <div id="bots" class="space-y-2"></div>
-    </section>
-    <section class="mb-4">
+    <input id="accountSearch" class="border w-full mb-2 p-1" placeholder="Search accounts">
+    <table id="accountTable" class="w-full text-sm"></table>
+  </section>
+
+  <section class="bg-white rounded shadow p-4 md:col-span-2" id="botsSection">
+    <div class="flex justify-between items-center mb-2">
+      <h2 class="text-lg font-bold">Bots</h2>
+      <button onclick="startScheduler()" class="bg-blue-600 hover:bg-blue-700 text-white px-3 py-1 rounded text-sm">Start Scheduler</button>
+    </div>
+    <input id="botSearch" class="border w-full mb-2 p-1" placeholder="Search bots">
+    <div id="bots" class="space-y-2"></div>
+    <div class="mt-4">
       <canvas id="chart" height="150"></canvas>
-    </section>
-    <section class="mt-6">
-      <h2 class="font-bold">Logs</h2>
-      <pre id="logBox" class="bg-gray-100 p-2 h-64 overflow-auto">Select a bot to view logs</pre>
-    </section>
-  </main>
+    </div>
+  </section>
+
+  <section class="bg-white rounded shadow p-4 md:col-span-2" id="logsSection">
+    <div class="flex justify-between items-center mb-2">
+      <h2 class="text-lg font-bold">Logs</h2>
+      <button onclick="syncPush()" class="bg-gray-600 hover:bg-gray-700 text-white px-3 py-1 rounded text-sm">Sync Now</button>
+    </div>
+    <pre id="logBox" class="bg-gray-100 p-2 h-64 overflow-auto">Select a bot to view logs</pre>
+  </section>
 </div>
 
 <dialog id="groupModal">

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -22,7 +22,7 @@ from shared.cache import init_cache
 from shared.logger import logger, init_logging
 from .models import db, SyncEvent
 from . import scheduler
-from .scheduler import sched, process_unsent_events
+from .scheduler import sched, process_unsent_events, set_socketio
 from .routes import api_bp, auth_bp
 from app.routes import register_web
 
@@ -75,6 +75,7 @@ def create_app(config: Optional[dict] = None) -> Flask:
     jwt.init_app(app)
     db.init_app(app)
     socketio.init_app(app)
+    set_socketio(socketio)
 
     scheduler.init_redis()
     app.redis_online = True
@@ -88,7 +89,7 @@ def create_app(config: Optional[dict] = None) -> Flask:
                 fb = Path(app.config["SYNC_FALLBACK_FILE"])
                 if fb.exists():
                     fb.unlink()
-                scheduler.queue.enqueue(process_unsent_events, socketio)
+                scheduler.queue.enqueue(process_unsent_events)
                 if not getattr(app, "redis_online", True):
                     logger.info("Redis connection restored")
                     socketio.emit("redis_status", {"online": True})

--- a/backend/scheduler.py
+++ b/backend/scheduler.py
@@ -12,11 +12,14 @@ from rq import Queue
 from apscheduler.executors.pool import ThreadPoolExecutor
 from apscheduler.schedulers.background import BackgroundScheduler
 from flask import current_app, Flask
+from flask_socketio import SocketIO
+
+SOCKETIO: Optional[SocketIO] = None
+
 from shared.config import load_config
 from shared.logger import logger, notify_webhook
 from bots.instance import BotInstance
 from .models import db, Group, Account, Log, SyncEvent
-from flask_socketio import SocketIO
 from prometheus_client import Counter, Gauge, CollectorRegistry
 
 Timer = _Timer
@@ -64,7 +67,16 @@ def init_redis() -> None:
         logger.warning("Redis unavailable, tasks will run inline")
 
 
-def log_sync_event(entity: str, action: str, payload: dict, socketio: SocketIO) -> None:
+def set_socketio(sock: SocketIO) -> None:
+    """Store socketio instance for tasks."""
+    global SOCKETIO
+    SOCKETIO = sock
+
+
+def log_sync_event(
+    entity: str, action: str, payload: dict, socketio: Optional[SocketIO] = None
+) -> None:
+    sio = socketio or SOCKETIO or current_app.extensions.get("socketio")
     evt = SyncEvent(
         event_id=str(uuid4()),
         entity=entity,
@@ -73,19 +85,20 @@ def log_sync_event(entity: str, action: str, payload: dict, socketio: SocketIO) 
     )
     db.session.add(evt)
     db.session.commit()
-    socketio.emit(
-        "sync_event",
-        {
-            "event_id": evt.event_id,
-            "entity": evt.entity,
-            "action": evt.action,
-            "payload": evt.payload,
-            "timestamp": evt.timestamp.isoformat(),
-        },
-    )
+    if sio:
+        sio.emit(
+            "sync_event",
+            {
+                "event_id": evt.event_id,
+                "entity": evt.entity,
+                "action": evt.action,
+                "payload": evt.payload,
+                "timestamp": evt.timestamp.isoformat(),
+            },
+        )
 
 
-def run_bot_task(bot_id: int, socketio: SocketIO) -> None:
+def run_bot_task(bot_id: int, socketio: Optional[SocketIO] = None) -> None:
     logger.info("starting bot task %s", bot_id)
     app = APP or current_app
     with app.app_context():
@@ -112,19 +125,23 @@ def run_bot_task(bot_id: int, socketio: SocketIO) -> None:
         account.password,
     ]
     runs_counter.inc()
+    sio = socketio or SOCKETIO or current_app.extensions.get("socketio")
     try:
         subprocess.run(cmd, check=True)
-        socketio.emit("bot_stopped", {"id": bot_id})
+        if sio:
+            sio.emit("bot_stopped", {"id": bot_id})
     except Exception as exc:  # noqa: broad-except
         errors_counter.inc()
         logger.error("bot run failed: %s", exc)
         webhook = cfg.SLACK_WEBHOOK
         if webhook:
             notify_webhook(webhook, f"Bot {bot_id} failed: {exc}")
-        socketio.emit("bot_error", {"id": bot_id})
+        if sio:
+            sio.emit("bot_error", {"id": bot_id})
 
 
-def schedule_all(socketio: SocketIO) -> None:
+def schedule_all(socketio: Optional[SocketIO] = None) -> None:
+    sio = socketio or SOCKETIO or current_app.extensions.get("socketio")
     sched.remove_all_jobs()
     for acc in Account.query.all():
         group = Group.query.get(acc.group_id)
@@ -133,7 +150,7 @@ def schedule_all(socketio: SocketIO) -> None:
         try:
             sched.add_job(
                 lambda aid=acc.id: asyncio.run_coroutine_threadsafe(
-                    send_job(aid, socketio), aio_loop
+                    send_job(aid, sio), aio_loop
                 ),
                 "interval",
                 seconds=group.interval,
@@ -144,7 +161,7 @@ def schedule_all(socketio: SocketIO) -> None:
             logger.error("could not schedule job %s: %s", acc.id, exc)
 
 
-async def send_job(account_id: int, socketio: SocketIO) -> None:
+async def send_job(account_id: int, socketio: Optional[SocketIO] = None) -> None:
     app = APP or current_app
     with app.app_context():
         account = Account.query.get(account_id)
@@ -164,35 +181,42 @@ async def send_job(account_id: int, socketio: SocketIO) -> None:
             line = fh.readline().strip()
             if line:
                 message = line
-    socketio.emit("bot_started", {"id": account_id})
+    sio = socketio or SOCKETIO or current_app.extensions.get("socketio")
+    if sio:
+        sio.emit("bot_started", {"id": account_id})
     try:
         await bot.send_message(message)
-        socketio.emit("bot_stopped", {"id": account_id})
+        if sio:
+            sio.emit("bot_stopped", {"id": account_id})
     except Exception as exc:  # noqa: broad-except
         errors_counter.inc()
         logger.error("send job failed: %s", exc)
-        socketio.emit("bot_error", {"id": account_id})
+        if sio:
+            sio.emit("bot_error", {"id": account_id})
     with app.app_context():
         log = Log(account_id=account_id, message=message)
         db.session.add(log)
         db.session.commit()
-    socketio.emit("status", {"message": f"sent message for {account_id}"})
+    if sio:
+        sio.emit("status", {"message": f"sent message for {account_id}"})
 
 
-def process_unsent_events(socketio: SocketIO) -> None:
+def process_unsent_events(socketio: Optional[SocketIO] = None) -> None:
     app = APP or current_app
+    sio = socketio or SOCKETIO or current_app.extensions.get("socketio")
     with app.app_context():
         events = SyncEvent.query.filter_by(synced=False).all()
         for evt in events:
-            socketio.emit(
-                "sync_event",
-                {
-                    "event_id": evt.event_id,
-                    "entity": evt.entity,
-                    "action": evt.action,
-                    "payload": evt.payload,
-                    "timestamp": evt.timestamp.isoformat(),
-                },
-            )
+            if sio:
+                sio.emit(
+                    "sync_event",
+                    {
+                        "event_id": evt.event_id,
+                        "entity": evt.entity,
+                        "action": evt.action,
+                        "payload": evt.payload,
+                        "timestamp": evt.timestamp.isoformat(),
+                    },
+                )
             evt.synced = True
         db.session.commit()


### PR DESCRIPTION
## Summary
- keep a global SocketIO instance in the scheduler
- update scheduled tasks to fetch the socketio instance internally
- enqueue sync job without passing SocketIO
- register the socketio instance when creating the app
- redesign KickBot dashboard UI with Tailwind cards, tables, and badges

## Testing
- `PYTHONPATH=. pytest -q` *(fails: cannot schedule new futures after interpreter shutdown)*

------
https://chatgpt.com/codex/tasks/task_e_688222d561588321b94ec09d97fb1db6