### PR TITLE
Improve dashboard UI and bot logs

### DIFF
--- a/app/static/main.js
+++ b/app/static/main.js
@@ -71,6 +71,10 @@ async function api(url, opts = {}) {
 function openModal(id) { document.getElementById(id).showModal(); }
 function closeModal(id) { document.getElementById(id).close(); }
 function closeCmd() { document.getElementById('cmdDialog').close(); }
+function openCmd(id) {
+  document.getElementById('cmd-id').value = id;
+  document.getElementById('cmdDialog').showModal();
+}
 
 async function syncPull() {
   const res = await api('/sync/pull');
@@ -141,20 +145,24 @@ async function loadBots() {
   const data = await api(url);
   if (!data) return;
   const bots = data.items || data;
-  const container = document.getElementById('bots');
-  container.innerHTML = '';
+  const table = document.getElementById('botTable');
+  table.innerHTML = '<tr><th>ID</th><th>User</th><th>Status</th><th>Actions</th></tr>';
   bots.forEach(b => {
-    const div = document.createElement('div');
-    let color = 'bg-red-200';
-    if (b.status === 'online') color = 'bg-green-200';
-    else if (b.status === 'queued') color = 'bg-yellow-200';
-    div.className = `${color} p-2 space-x-1`;
-    div.innerHTML = `ID ${b.id} (${b.username}) - ${b.status}
-      <button onclick="startBot(${b.id})" class="bg-green-500 text-white px-1">Start</button>
-      <button onclick="stopBot(${b.id})" class="bg-red-500 text-white px-1">Stop</button>
-      <button onclick="openCmd(${b.id})" class="bg-blue-500 text-white px-1">Cmd</button>
-      <button onclick="fetchLogs(${b.id})" class="text-sm underline">Logs</button>`;
-    container.appendChild(div);
+    const row = document.createElement('tr');
+    const badge = b.status === 'online'
+      ? '<span class="bg-green-500 text-white px-2 py-0.5 rounded">running</span>'
+      : '<span class="bg-red-500 text-white px-2 py-0.5 rounded">stopped</span>';
+    row.innerHTML =
+      `<td class="border px-2">${b.id}</td>` +
+      `<td class="border px-2">${b.username}</td>` +
+      `<td class="border px-2 text-center">${badge}</td>` +
+      `<td class="border px-2 space-x-1">` +
+        `<button onclick="startBot(${b.id})" class="bg-green-600 text-white px-2 py-1 text-xs rounded">Start</button>` +
+        `<button onclick="stopBot(${b.id})" class="bg-red-600 text-white px-2 py-1 text-xs rounded">Stop</button>` +
+        `<button onclick="openCmd(${b.id})" class="bg-blue-500 text-white px-2 py-1 text-xs rounded">Cmd</button>` +
+        `<button onclick="fetchLogs(${b.id})" class="underline text-xs">Logs</button>` +
+      `</td>`;
+    table.appendChild(row);
   });
 }
 
@@ -195,7 +203,9 @@ async function fetchLogs(id) {
   async function load() {
     const lines = await api(`/dashboard/api/bots/${id}/logs`);
     if (lines) {
-      document.getElementById('logBox').textContent = lines.join('\n');
+      const box = document.getElementById('logBox');
+      box.textContent = lines.join('\n');
+      box.scrollTop = box.scrollHeight;
     }
   }
   await load();
@@ -318,14 +328,16 @@ socket.on('redis_status', () => checkRedis());
 socket.on('sync_event', syncPull);
 socket.on('connect', () => { syncPull(); syncPush(); checkRedis(); });
 
-loadGroups();
-loadAccounts();
-loadBots();
-refreshStats();
-syncPull();
-syncPush();
-checkRedis();
-setInterval(checkRedis, 10000);
+document.addEventListener('DOMContentLoaded', () => {
+  loadGroups();
+  loadAccounts();
+  loadBots();
+  refreshStats();
+  syncPull();
+  syncPush();
+  checkRedis();
+  setInterval(checkRedis, 10000);
+});
 
 window.addEventListener('load', () => {
   if (!navigator.onLine) document.getElementById('offlineBanner').classList.remove('hidden');

--- a/app/static/main.js
+++ b/app/static/main.js
@@ -106,6 +106,10 @@ async function loadGroups() {
   const groups = data.items || data;
   const list = document.getElementById('groupList');
   list.innerHTML = '';
+  if (!groups.length) {
+    list.innerHTML = '<li class="text-gray-500 text-sm">No groups created yet</li>';
+    return;
+  }
   groups.forEach(g => {
     const li = document.createElement('li');
     li.className = 'mb-1';
@@ -132,6 +136,12 @@ async function loadAccounts() {
   const accs = data.items || data;
   const table = document.getElementById('accountTable');
   table.innerHTML = '<tr><th>ID</th><th>User</th><th>Group</th></tr>';
+  if (!accs.length) {
+    const row = document.createElement('tr');
+    row.innerHTML = '<td class="border px-2 text-center" colspan="3">No accounts</td>';
+    table.appendChild(row);
+    return;
+  }
   accs.forEach(a => {
     const row = document.createElement('tr');
     row.innerHTML = `<td class="border px-2">${a.id}</td><td class="border px-2">${a.username}</td><td class="border px-2">${a.group_id}</td>`;
@@ -147,6 +157,12 @@ async function loadBots() {
   const bots = data.items || data;
   const table = document.getElementById('botTable');
   table.innerHTML = '<tr><th>ID</th><th>User</th><th>Status</th><th>Actions</th></tr>';
+  if (!bots.length) {
+    const row = document.createElement('tr');
+    row.innerHTML = '<td class="border px-2 text-center" colspan="4">No bots created yet</td>';
+    table.appendChild(row);
+    return;
+  }
   bots.forEach(b => {
     const row = document.createElement('tr');
     const badge = b.status === 'online'
@@ -328,7 +344,7 @@ socket.on('redis_status', () => checkRedis());
 socket.on('sync_event', syncPull);
 socket.on('connect', () => { syncPull(); syncPush(); checkRedis(); });
 
-document.addEventListener('DOMContentLoaded', () => {
+window.addEventListener('load', () => {
   loadGroups();
   loadAccounts();
   loadBots();
@@ -337,8 +353,5 @@ document.addEventListener('DOMContentLoaded', () => {
   syncPush();
   checkRedis();
   setInterval(checkRedis, 10000);
-});
-
-window.addEventListener('load', () => {
   if (!navigator.onLine) document.getElementById('offlineBanner').classList.remove('hidden');
 });

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -1,37 +1,42 @@
 {% extends 'base.html' %}
 {% block title %}Dashboard{% endblock %}
 {% block content %}
-<h1 class="text-xl mb-4">KickBot Manager</h1>
-<div class="flex flex-col md:flex-row">
-  <aside class="md:w-1/4 p-2 bg-gray-50" id="sidebar">
-    <div class="flex justify-between items-center mb-2">
-      <span class="font-bold">Groups</span>
-      <button id="addGroupBtn" class="bg-green-600 text-white px-2 py-1 text-sm">Add</button>
+<h1 class="text-xl font-bold mb-4">KickBot Manager</h1>
+<div class="md:grid md:grid-cols-4 gap-4">
+  <section id="sidebar" class="md:col-span-1 space-y-4">
+    <div class="bg-white rounded shadow p-4">
+      <div class="flex justify-between items-center mb-2">
+        <h2 class="font-bold text-lg">Groups</h2>
+        <button id="addGroupBtn" class="bg-green-600 text-white px-2 py-1 text-sm rounded">Add</button>
+      </div>
+      <input id="groupSearch" class="border rounded w-full mb-2 p-1" placeholder="Search groups">
+      <ul id="groupList" class="space-y-1 text-sm"></ul>
     </div>
-    <input id="groupSearch" class="border w-full mb-2" placeholder="Search groups">
-    <ul id="groupList" class="space-y-1"></ul>
-  </aside>
-  <main class="md:flex-1 p-2" id="mainArea">
-    <button onclick="syncPush()" class="bg-gray-500 text-white px-2 py-1 mb-2">Sync Now</button>
-    <div class="flex justify-between items-center mb-2">
-      <span class="font-bold">Accounts</span>
-      <button id="addAccountBtn" class="bg-green-600 text-white px-2 py-1 text-sm">Add</button>
+  </section>
+  <main class="md:col-span-3 space-y-4" id="mainArea">
+    <div class="bg-white rounded shadow p-4">
+      <div class="flex justify-between items-center mb-2">
+        <h2 class="font-bold text-lg">Accounts</h2>
+        <button id="addAccountBtn" class="bg-green-600 text-white px-2 py-1 text-sm rounded">Add</button>
+      </div>
+      <input id="accountSearch" class="border rounded w-full mb-2 p-1" placeholder="Search accounts">
+      <table id="accountTable" class="w-full text-sm border-collapse"></table>
     </div>
-    <input id="accountSearch" class="border w-full mb-2" placeholder="Search accounts">
-    <table id="accountTable" class="w-full border-collapse mb-4"></table>
-    <section class="mb-4">
-      <h2 class="font-bold">Bots</h2>
-      <button onclick="startScheduler()" class="bg-blue-500 text-white px-2 py-1 mb-2">Start Scheduler</button>
-      <input id="botSearch" class="border w-full mb-2" placeholder="Search bots">
-      <div id="bots" class="space-y-2"></div>
-    </section>
-    <section class="mb-4">
+    <div class="bg-white rounded shadow p-4">
+      <div class="flex justify-between items-center mb-2">
+        <h2 class="font-bold text-lg">Bots</h2>
+        <button onclick="startScheduler()" class="bg-blue-500 text-white px-2 py-1 text-sm rounded">Start Scheduler</button>
+      </div>
+      <input id="botSearch" class="border rounded w-full mb-2 p-1" placeholder="Search bots">
+      <table id="botTable" class="w-full text-sm border-collapse"></table>
+    </div>
+    <div class="bg-white rounded shadow p-4">
       <canvas id="chart" height="150"></canvas>
-    </section>
-    <section class="mt-6">
-      <h2 class="font-bold">Logs</h2>
-      <pre id="logBox" class="bg-gray-100 p-2 h-64 overflow-auto">Select a bot to view logs</pre>
-    </section>
+    </div>
+    <div class="bg-white rounded shadow p-4">
+      <h2 class="font-bold text-lg mb-2">Logs</h2>
+      <pre id="logBox" class="bg-gray-100 p-2 h-64 overflow-auto rounded">Select a bot to view logs</pre>
+    </div>
   </main>
 </div>
 

--- a/backend/routes.py
+++ b/backend/routes.py
@@ -78,8 +78,8 @@ class GroupResource(Resource):
     @jwt_required(optional=True)
     def get(self):
         search = (request.args.get("search") or "").strip()
-        page = int(request.args.get("page", 1))
-        per_page = int(request.args.get("per_page", 50))
+        page = int(request.args.get("page") or 1)
+        per_page = int(request.args.get("per_page") or 50)
         if not search and page == 1 and per_page == 50:
             cached = cache.get("groups")
             if cached is not None:
@@ -141,8 +141,8 @@ class AccountResource(Resource):
     @jwt_required(optional=True)
     def get(self):
         search = (request.args.get("search") or "").strip()
-        page = int(request.args.get("page", 1))
-        per_page = int(request.args.get("per_page", 50))
+        page = int(request.args.get("page") or 1)
+        per_page = int(request.args.get("per_page") or 50)
         query = Account.query
         if search:
             query = query.filter(Account.username.ilike(f"%{search}%"))
@@ -197,8 +197,8 @@ class BotListResource(Resource):
     @jwt_required(optional=True)
     def get(self):
         search = (request.args.get("search") or "").strip()
-        page = int(request.args.get("page", 1))
-        per_page = int(request.args.get("per_page", 50))
+        page = int(request.args.get("page") or 1)
+        per_page = int(request.args.get("per_page") or 50)
         query = Account.query
         if search:
             query = query.filter(Account.username.ilike(f"%{search}%"))


### PR DESCRIPTION
## Summary
- restyle dashboard with Tailwind cards and responsive grid
- show bot status badges and refresh bot list after actions
- auto-scroll log output and start polling when selecting a bot
- wire up CMD dialog open function and move data load calls to DOMContentLoaded

## Testing
- `flake8`
- `python -m pytest tests/test_api.py tests/test_auth.py tests/test_sync.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6882304999e88321a46f30cb559fcc69