### PR TITLE
Fix API search defaults and error responses

### DIFF
--- a/app/static/main.js
+++ b/app/static/main.js
@@ -64,7 +64,9 @@ async function api(url, opts = {}) {
   }
   hideSpinner();
   if (!res) return null;
-  return res.json();
+  const data = await res.json();
+  if (data && data.error) showToast(data.error, false);
+  return data;
 }
 
 
@@ -244,9 +246,8 @@ document.getElementById('groupForm').addEventListener('submit', async e => {
     q.push({entity: 'group', action: 'create', payload: data, timestamp: new Date().toISOString()});
     saveQueue(q);
     showToast('Queued offline', true);
-  } else if (res.error) {
-    showToast(res.error, false);
   } else {
+    document.getElementById('groupSearch').value = '';
     loadGroups();
     closeModal('groupModal');
     syncPush();
@@ -273,9 +274,8 @@ document.getElementById('accountForm').addEventListener('submit', async e => {
     q.push({entity: 'account', action: 'create', payload: data, timestamp: new Date().toISOString()});
     saveQueue(q);
     showToast('Queued offline', true);
-  } else if (res.error) {
-    showToast(res.error, false);
   } else {
+    document.getElementById('accountSearch').value = '';
     loadAccounts();
     loadBots();
     closeModal('accountModal');
@@ -318,9 +318,7 @@ socket.on('redis_status', () => checkRedis());
 socket.on('sync_event', syncPull);
 socket.on('connect', () => { syncPull(); syncPush(); checkRedis(); });
 
-loadGroups();
 loadAccounts();
-loadBots();
 refreshStats();
 syncPull();
 syncPush();
@@ -329,4 +327,6 @@ setInterval(checkRedis, 10000);
 
 window.addEventListener('load', () => {
   if (!navigator.onLine) document.getElementById('offlineBanner').classList.remove('hidden');
+  loadGroups();
+  loadBots();
 });

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -22,7 +22,7 @@ from shared.cache import init_cache
 from shared.logger import logger, init_logging
 from .models import db, SyncEvent
 from . import scheduler
-from .scheduler import sched, process_unsent_events
+from .scheduler import sched, enqueue_sync_job
 from .routes import api_bp, auth_bp
 from app.routes import register_web
 
@@ -88,7 +88,7 @@ def create_app(config: Optional[dict] = None) -> Flask:
                 fb = Path(app.config["SYNC_FALLBACK_FILE"])
                 if fb.exists():
                     fb.unlink()
-                scheduler.queue.enqueue(process_unsent_events, socketio)
+                scheduler.queue.enqueue(enqueue_sync_job)
                 if not getattr(app, "redis_online", True):
                     logger.info("Redis connection restored")
                     socketio.emit("redis_status", {"online": True})

--- a/backend/routes.py
+++ b/backend/routes.py
@@ -77,7 +77,7 @@ def refresh_token():
 class GroupResource(Resource):
     @jwt_required(optional=True)
     def get(self):
-        search = (request.args.get("search") or "").strip()
+        search = request.args.get("search", "").strip()
         page = int(request.args.get("page", 1))
         per_page = int(request.args.get("per_page", 50))
         if not search and page == 1 and per_page == 50:
@@ -101,7 +101,7 @@ class GroupResource(Resource):
         result = {"items": groups, "total": pagination.total}
         if not search and page == 1 and per_page == 50:
             cache.set("groups", result, timeout=60)
-        return result
+        return result, 200
 
     @role_required("operator", "admin")
     def post(self):
@@ -110,7 +110,7 @@ class GroupResource(Resource):
         except ValidationError as err:
             logger.warning("invalid group payload: %s", err.messages)
             return {"errors": err.messages}, 400
-        if Group.query.filter_by(name=data["name"]).first():
+        if Group.query.filter(Group.name.ilike(data["name"])).first():
             logger.warning("duplicate group name %s", data["name"])
             return {"error": "Group name already exists."}, 400
         group = Group(**data)
@@ -140,7 +140,7 @@ class GroupResource(Resource):
 class AccountResource(Resource):
     @jwt_required(optional=True)
     def get(self):
-        search = (request.args.get("search") or "").strip()
+        search = request.args.get("search", "").strip()
         page = int(request.args.get("page", 1))
         per_page = int(request.args.get("per_page", 50))
         query = Account.query
@@ -151,7 +151,7 @@ class AccountResource(Resource):
             {"id": a.id, "username": a.username, "group_id": a.group_id}
             for a in pagination.items
         ]
-        return {"items": accounts, "total": pagination.total}
+        return {"items": accounts, "total": pagination.total}, 200
 
     @role_required("operator", "admin")
     def post(self):
@@ -167,7 +167,7 @@ class AccountResource(Resource):
                 "invalid group_id %s for account %s", group_id, data.get("username")
             )
             return {"error": "Invalid group_id"}, 400
-        if Account.query.filter_by(username=data["username"]).first():
+        if Account.query.filter(Account.username.ilike(data["username"])).first():
             logger.warning("duplicate account username %s", data["username"])
             return {"error": "account already exists"}, 400
         account = Account(**data)
@@ -196,7 +196,7 @@ class AccountResource(Resource):
 class BotListResource(Resource):
     @jwt_required(optional=True)
     def get(self):
-        search = (request.args.get("search") or "").strip()
+        search = request.args.get("search", "").strip()
         page = int(request.args.get("page", 1))
         per_page = int(request.args.get("per_page", 50))
         query = Account.query
@@ -216,7 +216,7 @@ class BotListResource(Resource):
                     "status": status,
                 }
             )
-        return {"items": bots, "total": pagination.total}
+        return {"items": bots, "total": pagination.total}, 200
 
     @role_required("operator", "admin")
     def post(self):
@@ -227,7 +227,7 @@ class BotListResource(Resource):
             return {"errors": err.messages}, 400
         if not Group.query.get(data["group_id"]):
             return {"error": "Invalid group_id"}, 400
-        if Account.query.filter_by(username=data["username"]).first():
+        if Account.query.filter(Account.username.ilike(data["username"])).first():
             return {"error": "account already exists"}, 400
         account = Account(**data)
         db.session.add(account)

--- a/backend/scheduler.py
+++ b/backend/scheduler.py
@@ -196,3 +196,10 @@ def process_unsent_events(socketio: SocketIO) -> None:
             )
             evt.synced = True
         db.session.commit()
+
+
+def enqueue_sync_job() -> None:
+    """Wrapper for queuing sync jobs without pickling local lambdas."""
+    from backend import socketio as _socketio
+
+    process_unsent_events(_socketio)


### PR DESCRIPTION
## Summary
- handle missing search parameters gracefully
- standardize error responses for duplicates
- always return `{items, total}` with status 200

## Testing
- `python -m pytest tests/test_api.py -vv -s`
- `python -m pytest tests/test_auth.py -vv -s`
- `python -m pytest tests/test_sync.py -vv -s`


------
https://chatgpt.com/codex/tasks/task_e_68825767df5483219546d8a26860315c