### PR TITLE
Fix RQ serialization error

### DIFF
--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -75,6 +75,8 @@ def create_app(config: Optional[dict] = None) -> Flask:
     jwt.init_app(app)
     db.init_app(app)
     socketio.init_app(app)
+    # expose the application instance for out-of-context RQ workers
+    scheduler.APP = app
 
     scheduler.init_redis()
     app.redis_online = True


### PR DESCRIPTION
## Summary
- set `scheduler.APP` so RQ workers have access to the Flask application instance
- keep using the `enqueue_sync_job` wrapper to avoid pickling the SocketIO object

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882694cf66c8321b7e0c0305dbdce9f